### PR TITLE
Add common cache for service portals

### DIFF
--- a/github-portal/cmd/github-portal/main.go
+++ b/github-portal/cmd/github-portal/main.go
@@ -41,7 +41,7 @@ func main() {
 		DefaultAuthHeader: "Authorization",
 		SetupProxy: func(p *proxy.HTTPProxy) {
 			p.Transport = &loggingTransport{
-				underlying: http.DefaultTransport,
+				underlying: p.Transport,
 			}
 		},
 	}

--- a/pkg/cache/cache.go
+++ b/pkg/cache/cache.go
@@ -1,0 +1,99 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cache
+
+import (
+	"sync"
+	"time"
+)
+
+// Cache defines the interface for a simple cache.
+type Cache interface {
+	Get(key string) ([]byte, bool)
+	Set(key string, value []byte, ttl time.Duration)
+	Delete(key string)
+}
+
+type cacheItem struct {
+	value      []byte
+	expiration time.Time
+}
+
+// InMemoryCache is an in-memory implementation of Cache.
+type InMemoryCache struct {
+	mu    sync.RWMutex
+	items map[string]cacheItem
+}
+
+// NewInMemoryCache creates a new InMemoryCache and starts a background janitor to clean up expired items.
+func NewInMemoryCache() *InMemoryCache {
+	c := &InMemoryCache{
+		items: make(map[string]cacheItem),
+	}
+	go c.janitor()
+	return c
+}
+
+// Get retrieves an item from the cache.
+func (c *InMemoryCache) Get(key string) ([]byte, bool) {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+
+	item, ok := c.items[key]
+	if !ok {
+		return nil, false
+	}
+
+	if time.Now().After(item.expiration) {
+		return nil, false
+	}
+
+	return item.value, true
+}
+
+// Set adds an item to the cache with a TTL.
+func (c *InMemoryCache) Set(key string, value []byte, ttl time.Duration) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	c.items[key] = cacheItem{
+		value:      value,
+		expiration: time.Now().Add(ttl),
+	}
+}
+
+// Delete removes an item from the cache.
+func (c *InMemoryCache) Delete(key string) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	delete(c.items, key)
+}
+
+func (c *InMemoryCache) janitor() {
+	ticker := time.NewTicker(5 * time.Minute)
+	defer ticker.Stop()
+
+	for range ticker.C {
+		c.mu.Lock()
+		now := time.Now()
+		for k, v := range c.items {
+			if now.After(v.expiration) {
+				delete(c.items, k)
+			}
+		}
+		c.mu.Unlock()
+	}
+}

--- a/pkg/cache/cache.go
+++ b/pkg/cache/cache.go
@@ -33,14 +33,19 @@ type cacheItem struct {
 
 // InMemoryCache is an in-memory implementation of Cache.
 type InMemoryCache struct {
-	mu    sync.RWMutex
-	items map[string]cacheItem
+	mu              sync.RWMutex
+	items           map[string]cacheItem
+	cleanupInterval time.Duration
 }
 
 // NewInMemoryCache creates a new InMemoryCache and starts a background janitor to clean up expired items.
-func NewInMemoryCache() *InMemoryCache {
+func NewInMemoryCache(cleanupInterval time.Duration) *InMemoryCache {
+	if cleanupInterval <= 0 {
+		cleanupInterval = 1 * time.Minute
+	}
 	c := &InMemoryCache{
-		items: make(map[string]cacheItem),
+		items:           make(map[string]cacheItem),
+		cleanupInterval: cleanupInterval,
 	}
 	go c.janitor()
 	return c
@@ -83,7 +88,7 @@ func (c *InMemoryCache) Delete(key string) {
 }
 
 func (c *InMemoryCache) janitor() {
-	ticker := time.NewTicker(5 * time.Minute)
+	ticker := time.NewTicker(c.cleanupInterval)
 	defer ticker.Stop()
 
 	for range ticker.C {

--- a/pkg/cache/cache_test.go
+++ b/pkg/cache/cache_test.go
@@ -21,7 +21,7 @@ import (
 )
 
 func TestInMemoryCache(t *testing.T) {
-	c := NewInMemoryCache()
+	c := NewInMemoryCache(0)
 
 	// Test Set and Get
 	c.Set("key1", []byte("value1"), 1*time.Minute)

--- a/pkg/cache/cache_test.go
+++ b/pkg/cache/cache_test.go
@@ -1,0 +1,50 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cache
+
+import (
+	"bytes"
+	"testing"
+	"time"
+)
+
+func TestInMemoryCache(t *testing.T) {
+	c := NewInMemoryCache()
+
+	// Test Set and Get
+	c.Set("key1", []byte("value1"), 1*time.Minute)
+	val, ok := c.Get("key1")
+	if !ok {
+		t.Fatal("Expected to find key1")
+	}
+	if !bytes.Equal(val, []byte("value1")) {
+		t.Errorf("Expected value1, got %s", val)
+	}
+
+	// Test Delete
+	c.Delete("key1")
+	_, ok = c.Get("key1")
+	if ok {
+		t.Fatal("Expected key1 to be deleted")
+	}
+
+	// Test Expiration
+	c.Set("key2", []byte("value2"), 1*time.Millisecond)
+	time.Sleep(2 * time.Millisecond)
+	_, ok = c.Get("key2")
+	if ok {
+		t.Fatal("Expected key2 to be expired")
+	}
+}

--- a/pkg/portals/server.go
+++ b/pkg/portals/server.go
@@ -80,9 +80,18 @@ func Run(ctx context.Context, config Config) error {
 	}
 
 	if cacheTTL > 0 {
-		c := cache.NewInMemoryCache()
+		cleanupInterval := 1 * time.Minute
+		if cleanupEnv := os.Getenv("CACHE_CLEANUP_INTERVAL"); cleanupEnv != "" {
+			if d, err := time.ParseDuration(cleanupEnv); err == nil {
+				cleanupInterval = d
+			} else {
+				log.Printf("Warning: invalid CACHE_CLEANUP_INTERVAL %q: %v", cleanupEnv, err)
+			}
+		}
+
+		c := cache.NewInMemoryCache(cleanupInterval)
 		p.Transport = proxy.NewCachingTransport(c, p.Transport, cacheTTL)
-		log.Printf("Enabled caching with TTL %v", cacheTTL)
+		log.Printf("Enabled caching with TTL %v (cleanup interval %v)", cacheTTL, cleanupInterval)
 	}
 
 	if config.SetupProxy != nil {

--- a/pkg/portals/server.go
+++ b/pkg/portals/server.go
@@ -23,6 +23,7 @@ import (
 	"os"
 	"time"
 
+	"github.com/gke-labs/service-portals/pkg/cache"
 	"github.com/gke-labs/service-portals/pkg/proxy"
 )
 
@@ -30,6 +31,7 @@ type Config struct {
 	DefaultTargetURL  string
 	DefaultAuthHeader string
 	SetupProxy        func(*proxy.HTTPProxy)
+	CacheTTL          time.Duration
 }
 
 func Run(ctx context.Context, config Config) error {
@@ -66,6 +68,21 @@ func Run(ctx context.Context, config Config) error {
 	p, err := proxy.NewHTTPProxy(targetURL, upstreamAuthToken, upstreamAuthHeader, caCertPath, caKeyPath)
 	if err != nil {
 		return fmt.Errorf("failed to create proxy: %w", err)
+	}
+
+	cacheTTL := config.CacheTTL
+	if cacheTTLEnv := os.Getenv("CACHE_TTL"); cacheTTLEnv != "" {
+		if d, err := time.ParseDuration(cacheTTLEnv); err == nil {
+			cacheTTL = d
+		} else {
+			log.Printf("Warning: invalid CACHE_TTL %q: %v", cacheTTLEnv, err)
+		}
+	}
+
+	if cacheTTL > 0 {
+		c := cache.NewInMemoryCache()
+		p.Transport = proxy.NewCachingTransport(c, p.Transport, cacheTTL)
+		log.Printf("Enabled caching with TTL %v", cacheTTL)
 	}
 
 	if config.SetupProxy != nil {

--- a/pkg/proxy/transport.go
+++ b/pkg/proxy/transport.go
@@ -1,0 +1,117 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package proxy
+
+import (
+	"bytes"
+	"encoding/gob"
+	"fmt"
+	"io"
+	"log"
+	"net/http"
+	"time"
+
+	"github.com/gke-labs/service-portals/pkg/cache"
+)
+
+// CachedResponse represents the structure we store in the cache.
+type CachedResponse struct {
+	StatusCode int
+	Header     http.Header
+	Body       []byte
+}
+
+// CachingTransport is an http.RoundTripper that caches GET responses.
+type CachingTransport struct {
+	Cache      cache.Cache
+	Transport  http.RoundTripper
+	DefaultTTL time.Duration
+}
+
+// NewCachingTransport creates a new CachingTransport.
+func NewCachingTransport(c cache.Cache, t http.RoundTripper, defaultTTL time.Duration) *CachingTransport {
+	if t == nil {
+		t = http.DefaultTransport
+	}
+	return &CachingTransport{
+		Cache:      c,
+		Transport:  t,
+		DefaultTTL: defaultTTL,
+	}
+}
+
+// RoundTrip implements the http.RoundTripper interface.
+func (c *CachingTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	// Only cache GET requests
+	if req.Method != http.MethodGet {
+		return c.Transport.RoundTrip(req)
+	}
+
+	key := req.URL.String()
+	if val, ok := c.Cache.Get(key); ok {
+		var cachedResp CachedResponse
+		buf := bytes.NewBuffer(val)
+		dec := gob.NewDecoder(buf)
+		err := dec.Decode(&cachedResp)
+		if err == nil {
+			log.Printf("Cache hit for %s", key)
+			return &http.Response{
+				StatusCode: cachedResp.StatusCode,
+				Status:     fmt.Sprintf("%d %s", cachedResp.StatusCode, http.StatusText(cachedResp.StatusCode)),
+				Header:     cachedResp.Header,
+				Body:       io.NopCloser(bytes.NewReader(cachedResp.Body)),
+				Request:    req,
+			}, nil
+		}
+		log.Printf("Failed to decode cached response for %s: %v", key, err)
+	}
+
+	resp, err := c.Transport.RoundTrip(req)
+	if err != nil {
+		return nil, err
+	}
+
+	// Read the body to cache it
+	bodyBytes, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return resp, err
+	}
+	resp.Body.Close()
+
+	// Reconstruct response body for returning
+	resp.Body = io.NopCloser(bytes.NewReader(bodyBytes))
+
+	// Cache the response
+	cachedResp := CachedResponse{
+		StatusCode: resp.StatusCode,
+		Header:     resp.Header,
+		Body:       bodyBytes,
+	}
+
+	var buf bytes.Buffer
+	enc := gob.NewEncoder(&buf)
+	if err := enc.Encode(cachedResp); err == nil {
+		c.Cache.Set(key, buf.Bytes(), c.DefaultTTL)
+		log.Printf("Cached response for %s", key)
+	} else {
+		log.Printf("Failed to encode response for %s: %v", key, err)
+	}
+
+	return resp, nil
+}
+
+func init() {
+	gob.Register(CachedResponse{})
+}

--- a/pkg/proxy/transport_test.go
+++ b/pkg/proxy/transport_test.go
@@ -27,7 +27,7 @@ import (
 
 func TestCachingTransport(t *testing.T) {
 	// Create a mock cache
-	memCache := cache.NewInMemoryCache()
+	memCache := cache.NewInMemoryCache(0)
 
 	// Create a mock upstream server
 	callCount := 0

--- a/pkg/proxy/transport_test.go
+++ b/pkg/proxy/transport_test.go
@@ -1,0 +1,87 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package proxy
+
+import (
+	"bytes"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/gke-labs/service-portals/pkg/cache"
+)
+
+func TestCachingTransport(t *testing.T) {
+	// Create a mock cache
+	memCache := cache.NewInMemoryCache()
+
+	// Create a mock upstream server
+	callCount := 0
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		callCount++
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte("hello"))
+	}))
+	defer ts.Close()
+
+	transport := NewCachingTransport(memCache, http.DefaultTransport, 1*time.Minute)
+
+	// First request (GET) - should miss cache and call upstream
+	req, _ := http.NewRequest("GET", ts.URL, nil)
+	resp, err := transport.RoundTrip(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+
+	if callCount != 1 {
+		t.Errorf("Expected call count 1, got %d", callCount)
+	}
+
+	body, _ := io.ReadAll(resp.Body)
+	if string(body) != "hello" {
+		t.Errorf("Expected body 'hello', got '%s'", body)
+	}
+
+	// Second request (GET) - should hit cache and NOT call upstream
+	resp2, err := transport.RoundTrip(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp2.Body.Close()
+
+	if callCount != 1 {
+		t.Errorf("Expected call count 1 (cached), got %d", callCount)
+	}
+
+	body2, _ := io.ReadAll(resp2.Body)
+	if string(body2) != "hello" {
+		t.Errorf("Expected body 'hello', got '%s'", body2)
+	}
+
+	// Third request (POST) - should NOT cache and call upstream
+	req3, _ := http.NewRequest("POST", ts.URL, bytes.NewReader([]byte("data")))
+	resp3, err := transport.RoundTrip(req3)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp3.Body.Close()
+
+	if callCount != 2 {
+		t.Errorf("Expected call count 2, got %d", callCount)
+	}
+}


### PR DESCRIPTION
I have implemented a common caching layer for the service portals to cache read operations (GET requests).

## Changes Made

### `pkg/cache`
- Created `cache.go` defining the `Cache` interface and `InMemoryCache` implementation.
- Added unit tests in `cache_test.go`.

### `pkg/proxy`
- Created `transport.go` implementing `CachingTransport` (an `http.RoundTripper`).
- Added unit tests in `transport_test.go`.

### `pkg/portals`
- Modified `server.go` to support `CacheTTL` in `Config` and reading `CACHE_TTL` from environment variables.

### `github-portal`
- Modified `main.go` to preserve the transport chain when setting up logging, allowing the cache to work.

## Verification Results

### Automated Tests
- All unit tests passed, including new tests for cache and transport.

### Manual Verification
- Ran `github-portal` with `CACHE_TTL=1m`.
- Verified that the second request to `/user` was a cache hit, as shown in the logs:
  ```
  --- GitHub Portal: Request Intercepted ---
  URL: https://api.github.com/user
  Method: GET
  Cache hit for https://api.github.com/user
  --- GitHub Portal: Response Intercepted ---
  Status: 200 OK
  ```

The cache is now ready to be used by all portals by setting the `CACHE_TTL` environment variable.
