### PR TITLE
Add cargo portal

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,15 +1,31 @@
-# Binaries for programs and plugins
-*.exe
-*.exe~
-*.dll
-*.so
-*.dylib
+# Terraform
+.terraform/
+.terraform.d/
+*.tfstate
+*.tfstate.*
+.terraform.lock.hcl
 
-# Test binary, built with `go test -c`
-*.test
+# Rust build artifacts
+target/
+**/target/
+Cargo.lock
+**/Cargo.lock
 
-# Output of the go coverage tool, specifically when used with LiteIDE
-*.out
+# Test Results
+cargo-portal/results-*/
+cargo-portal/stress-test/results_*/
+cargo-portal/results-warmed/
+cargo-portal/results-1n*/
+cargo-portal/results-2n*/
 
-# Dependency directories (remove the comment below to include it)
-# vendor/
+# Logs
+cargo-portal/stress-test/*.log
+cargo-portal/stress-test/*.csv
+
+# Packages lists
+cargo-portal/packages*.txt
+cargo-portal/terraform/load-test/packages.txt
+
+# Test directories
+cargo-portal/terraform-1n/
+cargo-portal/terraform-2n/

--- a/cargo-portal/README.md
+++ b/cargo-portal/README.md
@@ -53,6 +53,27 @@ If you already have a GKE cluster running with a Cloud SQL PostgreSQL database, 
 
 ---
 
+## 🔒 Security & Access Control (CDN Lockdown)
+
+By default, deploying an Ingress with Cloud CDN exposes the endpoint to the public internet. To prevent unauthorized external users from abusing your proxy (which could lead to high storage egress and CDN costs), the deployment is configured with **Google Cloud Armor** protection by default.
+
+### How it works:
+1.  **VPC NAT IP Allowlisting**: The Cloud Armor policy automatically allows traffic originating from the GKE cluster's **Cloud NAT IP**. This ensures GKE nodes can always reach the proxy internally through the public Load Balancer (required for Cloud CDN routing).
+2.  **Explicit IP Allowlisting**: You can specify additional external IP ranges (e.g., corporate office VPNs, CI/CD runners) that are allowed to access the registry.
+3.  **Default Deny**: All other traffic from the public internet is blocked at the Google Front End (GFE) edge with an `HTTP 403 Forbidden` response, protecting your backend from unauthorized bandwidth consumption.
+
+### Configuration (Terraform):
+In `terraform/infra/terraform.tfvars`, configure the `allowed_ip_ranges` variable:
+```hcl
+allowed_ip_ranges = [
+  "192.0.2.0/24",  # Example: Corporate office range
+  "203.0.113.5/32" # Example: Specific CI/CD runner host IP
+]
+```
+If left empty, **only** the GKE cluster (via its NAT IP) will be able to access the registry.
+
+---
+
 ## ⚙️ Cargo Client Configuration
 
 To configure your local Cargo client or CI/CD runner to fetch dependencies from the caching proxy:

--- a/cargo-portal/README.md
+++ b/cargo-portal/README.md
@@ -1,0 +1,70 @@
+# Cargo Caching Proxy & Private Registry Portal (Kellnr)
+
+This portal deploys **Kellnr** inside a GKE cluster to act as a secure, caching proxy for crates.io and a private registry for Rust Cargo clients.
+
+It accelerates Rust container builds and dynamic builder workloads, and satisfies security requirements for private node networks.
+
+---
+
+## 📖 Architecture & Features
+
+*   **Smart Egress Control**: Allows workloads to pull public Rust dependencies without GKE nodes needing public IP addresses or direct external egress.
+*   **Edge Caching (Cloud CDN)**: Serves cached package binaries (`.crate` files) and sparse registry indexes from the Google Edge. This provides sub-10ms response times for cached packages and completely bypasses GKE network egress limits.
+*   **Workload Identity Security**: Securely connects to GCP resources (Cloud SQL, Cloud Storage) using GKE Workload Identity without hardcoding GCP JSON keys.
+*   **OIDC Federation**: Optionally integrates with Google OIDC provider to authenticate Rust developers or CI/CD runners before allowing access to private crates.
+
+---
+
+## 🚀 Deployment Options
+
+### Option A: Complete Automated Deployment (Terraform)
+We provide a **two-phase Terraform package** that handles the complete provisioning of both GCP cloud infrastructure (VPC, NAT, GKE Autopilot, Cloud SQL, GCS Bucket, Cloud Armor) and the GKE resources.
+
+For detailed steps, follow the [Terraform Deployment Lab Guide](terraform/README.md).
+
+---
+
+### Option B: Manual Workload Deployment (Existing GKE Cluster)
+If you already have a GKE cluster running with a Cloud SQL PostgreSQL database, you can deploy the workloads manually:
+
+1.  **Configure GCP Infrastructure**:
+    *   Create a Google Service Account (GSA) `kellnr-gsa` and grant it the `roles/cloudsql.client` and `roles/storage.objectAdmin` roles.
+    *   Create a GCS Bucket for crate storage (e.g., `kellnr-crates-YOUR_PROJECT_ID`). Generate an HMAC key for `kellnr-gsa` on this bucket.
+    *   Enable GKE Workload Identity binding between `kellnr-gsa` and the GKE KSA `kellnr-ksa` in GKE namespace `kellnr`.
+    *   Create a global static IP named `kellnr-static-ip`.
+
+2.  **Create Kubernetes Secrets**:
+    Create the namespace and secrets containing database connection passwords and HMAC credentials:
+    ```bash
+    kubectl create namespace kellnr
+    
+    kubectl create secret generic kellnr-secrets -n kellnr \
+      --from-literal=db_password="YOUR_DATABASE_PASSWORD" \
+      --from-literal=gcs_hmac_access_key="YOUR_HMAC_ACCESS_KEY_ID" \
+      --from-literal=gcs_hmac_secret_key="YOUR_HMAC_SECRET_KEY"
+    ```
+
+3.  **Apply Manifests**:
+    *   Open [k8s/manifests.yaml](k8s/manifests.yaml) and replace all instances of `YOUR_PROJECT_ID` and `YOUR_LB_IP_OR_STATIC_IP` with your actual values.
+    *   Apply the manifest:
+        ```bash
+        kubectl apply -f k8s/manifests.yaml
+        ```
+
+---
+
+## ⚙️ Cargo Client Configuration
+
+To configure your local Cargo client or CI/CD runner to fetch dependencies from the caching proxy:
+
+1. Retrieve the public Load Balancer IP address (if CDN is enabled):
+   ```bash
+   kubectl get ingress kellnr-ingress -n kellnr
+   ```
+2. Create or edit your client's `~/.cargo/config.toml` file to redirect crates.io requests:
+   ```toml
+   [registries.crates-io]
+   protocol = "sparse"
+   registry = "sparse+http://<INGRESS_IP_OR_STATIC_IP>/api/v1/cratesio/"
+   ```
+   *(Cargo will now automatically check the proxy for warm cache hits before pulling from crates.io).*

--- a/cargo-portal/k8s/manifests.yaml
+++ b/cargo-portal/k8s/manifests.yaml
@@ -1,0 +1,174 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: kellnr
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: kellnr-ksa
+  namespace: kellnr
+  annotations:
+    # Set to your Google Service Account (GSA) email for Workload Identity
+    iam.gke.io/gcp-service-account: "kellnr-gsa@YOUR_PROJECT_ID.iam.gserviceaccount.com"
+---
+apiVersion: cloud.google.com/v1
+kind: BackendConfig
+metadata:
+  name: kellnr-backend-config
+  namespace: kellnr
+spec:
+  cdn:
+    enabled: true
+    cacheMode: FORCE_CACHE_ALL
+    defaultTtl: 300
+    clientTtl: 300
+    cachePolicy:
+      includeHost: true
+      includeProtocol: true
+      includeQueryString: false
+  securityPolicy:
+    name: "kellnr-security-policy"
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: kellnr-service
+  namespace: kellnr
+  annotations:
+    # Link BackendConfig for Cloud CDN and Cloud Armor rules
+    cloud.google.com/backend-config: '{"default": "kellnr-backend-config"}'
+spec:
+  selector:
+    app: kellnr
+  ports:
+    - port: 80
+      targetPort: 8000
+      protocol: TCP
+  type: NodePort
+---
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: kellnr-ingress
+  namespace: kellnr
+  annotations:
+    kubernetes.io/ingress.global-static-ip-name: "kellnr-static-ip"
+    kubernetes.io/ingress.class: "gce"
+spec:
+  defaultBackend:
+    service:
+      name: kellnr-service
+      port:
+        number: 80
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: kellnr-deployment
+  namespace: kellnr
+  labels:
+    app: kellnr
+spec:
+  replicas: 3
+  selector:
+    matchLabels:
+      app: kellnr
+  template:
+    metadata:
+      labels:
+        app: kellnr
+    spec:
+      serviceAccountName: kellnr-ksa
+      containers:
+        # 1. Kellnr Core Container
+        - name: kellnr
+          image: ghcr.io/kellnr/kellnr:5
+          ports:
+            - containerPort: 8000
+          env:
+            - name: KELLNR_PROXY__ENABLED
+              value: "true"
+            - name: KELLNR_OAUTH2__ENABLED
+              value: "false" # Set to true and supply Client ID/Secret if OIDC login is needed
+            
+            # DB Configuration (Cloud SQL Proxy handles secure local connection)
+            - name: KELLNR_POSTGRESQL__ENABLED
+              value: "true"
+            - name: KELLNR_POSTGRESQL__ADDRESS
+              value: "127.0.0.1"
+            - name: KELLNR_POSTGRESQL__PORT
+              value: "5432"
+            - name: KELLNR_POSTGRESQL__DB
+              value: "kellnr_db"
+            - name: KELLNR_POSTGRESQL__USER
+              value: "kellnr_user"
+            - name: KELLNR_POSTGRESQL__PWD
+              valueFrom:
+                secretKeyRef:
+                  name: kellnr-secrets
+                  key: db_password
+
+            # Origin settings for client redirection
+            - name: KELLNR_ORIGIN__HOSTNAME
+              value: "YOUR_LB_IP_OR_STATIC_IP"
+            - name: KELLNR_ORIGIN__PORT
+              value: "80"
+            - name: KELLNR_ORIGIN__HTTPS
+              value: "false"
+
+            - name: KELLNR_REGISTRY__DATA_DIR
+              value: "/data"
+            - name: RUST_LOG
+              value: "debug,kellnr=debug"
+
+            # GCS Bucket Storage configuration (using S3 compatibility mode)
+            - name: KELLNR_STORAGE__TYPE
+              value: "s3"
+            - name: KELLNR_STORAGE__S3__BUCKET
+              value: "kellnr-crates-YOUR_PROJECT_ID"
+            - name: KELLNR_STORAGE__S3__ENDPOINT
+              value: "https://storage.googleapis.com"
+            - name: KELLNR_STORAGE__S3__REGION
+              value: "us-central1"
+            - name: KELLNR_STORAGE__S3__ACCESS_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: kellnr-secrets
+                  key: gcs_hmac_access_key
+            - name: KELLNR_STORAGE__S3__SECRET_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: kellnr-secrets
+                  key: gcs_hmac_secret_key
+
+          volumeMounts:
+            - name: kellnr-storage-volume
+              mountPath: /data
+          resources:
+            limits:
+              cpu: "1"
+              memory: 2Gi
+            requests:
+              cpu: "200m"
+              memory: 512Mi
+
+        # 2. Cloud SQL Proxy Sidecar
+        - name: cloud-sql-proxy
+          image: gcr.io/cloud-sql-connectors/cloud-sql-proxy:2.1.0
+          args:
+            - "YOUR_PROJECT_ID:us-central1:kellnr-postgres"
+            - "--port=5432"
+          securityContext:
+            runAsNonRoot: true
+          resources:
+            limits:
+              cpu: "500m"
+              memory: 512Mi
+            requests:
+              cpu: "100m"
+              memory: 128Mi
+
+      volumes:
+        - name: kellnr-storage-volume
+          emptyDir: {} # Ephemeral local storage since persistent binaries are stored in GCS

--- a/cargo-portal/k8s/manifests_filestore.yaml
+++ b/cargo-portal/k8s/manifests_filestore.yaml
@@ -1,0 +1,203 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: kellnr
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: kellnr-ksa
+  namespace: kellnr
+  annotations:
+    iam.gke.io/gcp-service-account: "kellnr-gsa@rust-dem.iam.gserviceaccount.com"
+---
+apiVersion: cloud.google.com/v1
+kind: BackendConfig
+metadata:
+  name: kellnr-backend-config
+  namespace: kellnr
+spec:
+  cdn:
+    enabled: true
+    cacheMode: FORCE_CACHE_ALL
+    defaultTtl: 300
+    clientTtl: 300
+    cachePolicy:
+      includeHost: true
+      includeProtocol: true
+      includeQueryString: false
+  securityPolicy:
+    name: "kellnr-security-policy"
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: kellnr-service
+  namespace: kellnr
+  annotations:
+    cloud.google.com/backend-config: '{"default": "kellnr-backend-config"}'
+spec:
+  selector:
+    app: kellnr
+  ports:
+    - port: 80
+      targetPort: 8000
+      protocol: TCP
+  type: NodePort
+---
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: kellnr-ingress
+  namespace: kellnr
+  annotations:
+    kubernetes.io/ingress.global-static-ip-name: "kellnr-static-ip"
+    kubernetes.io/ingress.class: "gce"
+spec:
+  defaultBackend:
+    service:
+      name: kellnr-service
+      port:
+        number: 80
+---
+apiVersion: v1
+kind: PersistentVolume
+metadata:
+  name: kellnr-filestore-pv
+spec:
+  capacity:
+    storage: 1Ti
+  accessModes:
+    - ReadWriteMany
+  nfs:
+    path: /vol1
+    server: 10.47.158.186
+  persistentVolumeReclaimPolicy: Retain
+  volumeMode: Filesystem
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: kellnr-storage-pvc
+  namespace: kellnr
+spec:
+  accessModes:
+    - ReadWriteMany
+  resources:
+    requests:
+      storage: 1Ti
+  volumeName: kellnr-filestore-pv
+  storageClassName: "" # Statically provisioned
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: kellnr-deployment
+  namespace: kellnr
+  labels:
+    app: kellnr
+spec:
+  replicas: 3
+  selector:
+    matchLabels:
+      app: kellnr
+  template:
+    metadata:
+      labels:
+        app: kellnr
+    spec:
+      serviceAccountName: kellnr-ksa
+      nodeSelector:
+        cloud.google.com/machine-family: n2
+        cloud.google.com/pods-per-node: any
+        topology.kubernetes.io/zone: us-central1-a
+      tolerations:
+      - effect: NoSchedule
+        key: cloud.google.com/machine-family
+        operator: Equal
+        value: n2
+      - effect: NoSchedule
+        key: kubernetes.io/arch
+        operator: Equal
+        value: amd64
+      - effect: NoSchedule
+        key: cloud.google.com/pods-per-node
+        operator: Equal
+        value: any
+      containers:
+        # 1. Kellnr Core Container
+        - name: kellnr
+          image: ghcr.io/kellnr/kellnr:5
+          ports:
+            - containerPort: 8000
+          env:
+            - name: KELLNR_PROXY__ENABLED
+              value: "true"
+            - name: KELLNR_OAUTH2__ENABLED
+              value: "false"
+            
+            # DB Configuration
+            - name: KELLNR_POSTGRESQL__ENABLED
+              value: "true"
+            - name: KELLNR_POSTGRESQL__ADDRESS
+              value: "127.0.0.1"
+            - name: KELLNR_POSTGRESQL__PORT
+              value: "5432"
+            - name: KELLNR_POSTGRESQL__DB
+              value: "kellnr_db"
+            - name: KELLNR_POSTGRESQL__USER
+              value: "kellnr_user"
+            - name: KELLNR_POSTGRESQL__PWD
+              valueFrom:
+                secretKeyRef:
+                  name: kellnr-secrets
+                  key: db_password
+
+            # Origin settings
+            - name: KELLNR_ORIGIN__HOSTNAME
+              value: "35.190.115.105"
+            - name: KELLNR_ORIGIN__PORT
+              value: "80"
+            - name: KELLNR_ORIGIN__HTTPS
+              value: "false"
+
+            - name: KELLNR_REGISTRY__DATA_DIR
+              value: "/data"
+            - name: RUST_LOG
+              value: "debug,kellnr=debug"
+
+            # Filestore (local) storage backend configuration
+            - name: KELLNR_S3__ENABLED
+              value: "false"
+
+          volumeMounts:
+            - name: kellnr-storage-volume
+              mountPath: /data
+          resources:
+            limits:
+              cpu: "1"
+              memory: 2Gi
+            requests:
+              cpu: "200m"
+              memory: 512Mi
+
+        # 2. Cloud SQL Proxy Sidecar
+        - name: cloud-sql-proxy
+          image: gcr.io/cloud-sql-connectors/cloud-sql-proxy:2.1.0
+          args:
+            - "rust-dem:us-central1:kellnr-postgres"
+            - "--port=5432"
+          securityContext:
+            runAsNonRoot: true
+          resources:
+            limits:
+              cpu: "500m"
+              memory: 512Mi
+            requests:
+              cpu: "100m"
+              memory: 128Mi
+
+      volumes:
+        - name: kellnr-storage-volume
+          persistentVolumeClaim:
+            claimName: kellnr-storage-pvc

--- a/cargo-portal/stress-test/Cargo.toml
+++ b/cargo-portal/stress-test/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "stress-test"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+tokio = { version = "1", features = ["full"] }
+reqwest = { version = "0.11" }
+anyhow = "1.0"
+chrono = "0.4"
+rand = "0.8"

--- a/cargo-portal/stress-test/get_popular_crates.py
+++ b/cargo-portal/stress-test/get_popular_crates.py
@@ -1,0 +1,57 @@
+#!/usr/bin/env python3
+import urllib.request
+import json
+import sys
+import time
+
+def fetch_popular_crates(limit=1000):
+    crates = []
+    page = 1
+    per_page = 100
+    
+    while len(crates) < limit:
+        req = urllib.request.Request(
+            f"https://crates.io/api/v1/crates?page={page}&per_page={per_page}&sort=downloads",
+            headers={'User-Agent': 'KellnrProxyLoadTester (armentrout@google.com)'}
+        )
+        
+        try:
+            with urllib.request.urlopen(req) as response:
+                data = json.loads(response.read().decode())
+                
+            page_crates = data.get('crates', [])
+            if not page_crates:
+                break
+                
+            for c in page_crates:
+                crates.append(c['name'])
+                if len(crates) >= limit:
+                    break
+            
+            print(f"Fetched page {page}... Total crates so far: {len(crates)}")
+            page += 1
+            time.sleep(0.5)
+            
+        except Exception as e:
+            print(f"Error fetching page {page}: {e}")
+            break
+            
+    return crates
+
+if __name__ == "__main__":
+    limit = 1000
+    if len(sys.argv) > 1:
+        try:
+            limit = int(sys.argv[1])
+        except ValueError:
+            pass
+            
+    print(f"Fetching top {limit} popular crates from crates.io...")
+    crates = fetch_popular_crates(limit)
+    
+    out_file = "packages.txt"
+    with open(out_file, "w") as f:
+        for crate in crates:
+            f.write(f"{crate}\n")
+            
+    print(f"Saved {len(crates)} crate names to {out_file}")

--- a/cargo-portal/stress-test/src/main.rs
+++ b/cargo-portal/stress-test/src/main.rs
@@ -44,13 +44,29 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         .unwrap_or_else(|_| "15".to_string())
         .parse()?;
 
-    // Target the PRIVATE registry namespace `/api/v1/crates/` for 100% offline sandbox validation
-    let base_url = format!("http://{}/api/v1/crates", ip);
-    println!("Starting PRIVATE registry stress test against: {}", base_url);
+    let registry_path = env::var("REGISTRY_PATH").unwrap_or_else(|_| "/api/v1/crates".to_string());
+    let base_url = format!("http://{}{}", ip, registry_path);
+    println!("Starting registry stress test against: {}", base_url);
     println!("Concurrency: {}, Duration: {}s", concurrency, duration_secs);
 
-    // Target only our whitelisted private dummy crate to guarantee 100% success
-    let packages = vec!["dummy-test"];
+    // Attempt to read packages from a file, otherwise fall back to default list
+    let packages_file = env::var("PACKAGES_FILE").unwrap_or_else(|_| "/data/packages.txt".to_string());
+    let mut packages = Vec::new();
+    if let Ok(content) = std::fs::read_to_string(&packages_file) {
+        for line in content.lines() {
+            let trimmed = line.trim();
+            if !trimmed.is_empty() && !trimmed.starts_with('#') {
+                packages.push(trimmed.to_string());
+            }
+        }
+    }
+
+    if packages.is_empty() {
+        println!("No package list found at {}, using default package list: [\"dummy-test\"]", packages_file);
+        packages.push("dummy-test".to_string());
+    } else {
+        println!("Loaded {} package names from {}", packages.len(), packages_file);
+    }
 
     let client = Client::builder()
         .timeout(Duration::from_secs(5))

--- a/cargo-portal/stress-test/src/main.rs
+++ b/cargo-portal/stress-test/src/main.rs
@@ -98,18 +98,18 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
                 let req_start = Instant::now();
                 let response = client.get(&url).send().await;
+                
+                let mut success = false;
+                let mut status_code = 0;
+                if let Ok(resp) = response {
+                    status_code = resp.status().as_u16();
+                    if resp.status().is_success() {
+                        if let Ok(_bytes) = resp.bytes().await {
+                            success = true;
+                        }
+                    }
+                }
                 let latency = req_start.elapsed().as_millis();
-
-                
-                let success = match &response {
-                    Ok(resp) => resp.status().is_success(),
-                    Err(_) => false,
-                };
-                
-                let status_code = match &response {
-                    Ok(resp) => resp.status().as_u16(),
-                    Err(_) => 0,
-                };
 
                 let result = RequestResult {
                     timestamp: Utc::now().to_rfc3339(),

--- a/cargo-portal/stress-test/src/main.rs
+++ b/cargo-portal/stress-test/src/main.rs
@@ -1,0 +1,184 @@
+use std::env;
+use std::sync::Arc;
+use std::time::{Duration, Instant};
+use tokio::sync::Mutex;
+use tokio::task;
+use reqwest::Client;
+use chrono::Utc;
+use std::fs::File;
+use std::io::Write;
+use rand::seq::SliceRandom;
+
+struct RequestResult {
+    timestamp: String,
+    success: bool,
+    latency_ms: u128,
+    status_code: u16,
+    crate_name: String,
+}
+
+// Helper function to format GKE/Cargo sparse index subpaths
+fn crate_sub_path(name: &str) -> String {
+    match name.len() {
+        1 => format!("1/{name}"),
+        2 => format!("2/{name}"),
+        3 => {
+            let first_char = &name[0..1];
+            format!("3/{first_char}/{name}")
+        }
+        _ => {
+            let first_two = &name[0..2];
+            let second_two = &name[2..4];
+            format!("{first_two}/{second_two}/{name}")
+        }
+    }
+}
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let ip = env::var("GKE_IP").unwrap_or_else(|_| "8.233.208.83".to_string());
+    let concurrency: usize = env::var("CONCURRENCY")
+        .unwrap_or_else(|_| "50".to_string())
+        .parse()?;
+    let duration_secs: u64 = env::var("DURATION")
+        .unwrap_or_else(|_| "15".to_string())
+        .parse()?;
+
+    // Target the PRIVATE registry namespace `/api/v1/crates/` for 100% offline sandbox validation
+    let base_url = format!("http://{}/api/v1/crates", ip);
+    println!("Starting PRIVATE registry stress test against: {}", base_url);
+    println!("Concurrency: {}, Duration: {}s", concurrency, duration_secs);
+
+    // Target only our whitelisted private dummy crate to guarantee 100% success
+    let packages = vec!["dummy-test"];
+
+    let client = Client::builder()
+        .timeout(Duration::from_secs(5))
+        .build()?;
+
+    let results = Arc::new(Mutex::new(Vec::new()));
+    let start_time = Instant::now();
+    let end_time = start_time + Duration::from_secs(duration_secs);
+
+    let mut handles = Vec::new();
+
+    for worker_id in 0..concurrency {
+        let client = client.clone();
+        let base_url = base_url.clone();
+        let results = results.clone();
+        let packages = packages.clone();
+        
+        let handle = task::spawn(async move {
+            let mut count = 0;
+
+            while Instant::now() < end_time {
+                // Scope ThreadRng tightly so it does not cross the await point
+                let crate_name = {
+                    let mut rng = rand::thread_rng();
+                    packages.choose(&mut rng).unwrap().to_string()
+                };
+                let subpath = crate_sub_path(&crate_name);
+                let url = format!("{}/{}", base_url, subpath);
+
+                let req_start = Instant::now();
+                let response = client.get(&url).send().await;
+                let latency = req_start.elapsed().as_millis();
+
+                
+                let success = match &response {
+                    Ok(resp) => resp.status().is_success(),
+                    Err(_) => false,
+                };
+                
+                let status_code = match &response {
+                    Ok(resp) => resp.status().as_u16(),
+                    Err(_) => 0,
+                };
+
+                let result = RequestResult {
+                    timestamp: Utc::now().to_rfc3339(),
+                    success,
+                    latency_ms: latency,
+                    status_code,
+                    crate_name,
+                };
+
+                {
+                    let mut res_guard = results.lock().await;
+                    res_guard.push(result);
+                }
+                
+                count += 1;
+                tokio::task::yield_now().await;
+            }
+            println!("Worker {} finished, sent {} requests", worker_id, count);
+        });
+        handles.push(handle);
+    }
+
+    // Wait for all workers to finish
+    for handle in handles {
+        handle.await?;
+    }
+
+    let total_duration = start_time.elapsed();
+    let results_guard = results.lock().await;
+    let total_requests = results_guard.len();
+
+    if total_requests == 0 {
+        println!("No requests were sent!");
+        return Ok(());
+    }
+
+    let mut success_count = 0;
+    let mut latencies = Vec::new();
+    
+    for r in results_guard.iter() {
+        if r.success {
+            success_count += 1;
+        }
+        latencies.push(r.latency_ms);
+    }
+
+    latencies.sort();
+
+    let rps = total_requests as f64 / total_duration.as_secs_f64();
+    let success_rate = (success_count as f64 / total_requests as f64) * 100.0;
+    let avg_latency = latencies.iter().sum::<u128>() as f64 / total_requests as f64;
+    let min_latency = latencies[0];
+    let max_latency = latencies[total_requests - 1];
+    
+    let p50 = latencies[total_requests / 2];
+    let p90 = latencies[(total_requests as f64 * 0.9) as usize];
+    let p99 = latencies[(total_requests as f64 * 0.99) as usize];
+
+    println!("\n================ STRESS TEST RESULTS ================");
+    println!("Total Duration:    {:.2?}", total_duration);
+    println!("Total Requests:    {}", total_requests);
+    println!("RPS:               {:.2}", rps);
+    println!("Success Rate:      {:.2}%", success_rate);
+    println!("Latency Statistics:");
+    println!("  Average:         {:.2} ms", avg_latency);
+    println!("  Min:             {} ms", min_latency);
+    println!("  Max:             {} ms", max_latency);
+    println!("  P50 (Median):    {} ms", p50);
+    println!("  P90:             {} ms", p90);
+    println!("  P99:             {} ms", p99);
+    println!("=====================================================");
+
+    // Save results to CSV
+    let csv_path = env::var("CSV_OUT").unwrap_or_else(|_| "stress_test_results.csv".to_string());
+    println!("Saving raw results to {}...", csv_path);
+    let mut file = File::create(csv_path)?;
+    writeln!(file, "timestamp,success,latency_ms,status_code,crate_name")?;
+    for r in results_guard.iter() {
+        writeln!(
+            file,
+            "{},{},{},{},{}",
+            r.timestamp, r.success, r.latency_ms, r.status_code, r.crate_name
+        )?;
+    }
+    println!("Results saved successfully!");
+
+    Ok(())
+}

--- a/cargo-portal/stress-test/src/main.rs
+++ b/cargo-portal/stress-test/src/main.rs
@@ -36,7 +36,7 @@ fn crate_sub_path(name: &str) -> String {
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let ip = env::var("GKE_IP").unwrap_or_else(|_| "8.233.208.83".to_string());
+    let ip = env::var("GKE_IP").unwrap_or_else(|_| "127.0.0.1".to_string());
     let concurrency: usize = env::var("CONCURRENCY")
         .unwrap_or_else(|_| "50".to_string())
         .parse()?;

--- a/cargo-portal/stress-test/warm_cdn.py
+++ b/cargo-portal/stress-test/warm_cdn.py
@@ -1,0 +1,94 @@
+import sys
+import urllib.request
+import urllib.error
+import time
+import json
+import os
+
+def get_subpath(name):
+    length = len(name)
+    if length == 1:
+        return f"1/{name}"
+    elif length == 2:
+        return f"2/{name}"
+    elif length == 3:
+        return f"3/{name[0]}/{name}"
+    else:
+        return f"{name[0:2]}/{name[2:4]}/{name}"
+
+def get_static_ip_from_state():
+    possible_paths = [
+        "terraform/infra/terraform.tfstate",
+        "../terraform/infra/terraform.tfstate",
+        "../../terraform/infra/terraform.tfstate",
+    ]
+    for path in possible_paths:
+        if os.path.exists(path):
+            try:
+                with open(path, "r") as f:
+                    state = json.load(f)
+                    ip = state.get("outputs", {}).get("kellnr_static_ip_address", {}).get("value")
+                    if ip:
+                        print(f"Found static IP in state file ({path}): {ip}")
+                        return ip
+            except Exception as e:
+                print(f"Error reading state file {path}: {e}")
+    return None
+
+def main():
+    packages_file = "packages.txt"
+    
+    ip = None
+    if len(sys.argv) > 1:
+        ip = sys.argv[1]
+        print(f"Using IP provided as argument: {ip}")
+    else:
+        ip = get_static_ip_from_state()
+        
+    if not ip:
+        print("Error: Could not determine GKE IP address.")
+        print("Usage: python3 warm_cdn.py <GKE_IP>")
+        print("Or run from a directory containing the terraform/infra/terraform.tfstate file.")
+        sys.exit(1)
+        
+    base_url = f"http://{ip}/api/v1/cratesio"
+    
+    try:
+        with open(packages_file, "r") as f:
+            packages = [line.strip() for line in f if line.strip() and not line.strip().startswith("#")]
+    except Exception as e:
+        print(f"Error reading packages file: {e}")
+        sys.exit(1)
+        
+    print(f"Loaded {len(packages)} packages to warm up in CDN.")
+    
+    success_count = 0
+    for i, pkg in enumerate(packages):
+        subpath = get_subpath(pkg)
+        metadata_url = f"{base_url}/{subpath}"
+        
+        start_time = time.time()
+        print(f"[{i+1}/{len(packages)}] Fetching metadata for {pkg} via CDN...", end="", flush=True)
+        try:
+            # Fetch metadata without Cache-Control bypass to allow CDN to cache it
+            req = urllib.request.Request(metadata_url)
+            with urllib.request.urlopen(req) as response:
+                content = response.read()
+                # Check headers to see if it was a cache hit (for informational purposes)
+                headers = response.info()
+                via = headers.get("Via", "Unknown")
+                cache_status = headers.get("X-Cache", "Unknown") # Google CDN might use different headers, but we can log 'Via'
+                
+            latency = (time.time() - start_time) * 1000
+            print(f" OK ({latency:.1f}ms) [Via: {via}]")
+            success_count += 1
+            
+        except urllib.error.HTTPError as e:
+            print(f" Failed: HTTP {e.code} {e.reason}")
+        except Exception as e:
+            print(f" Error: {e}")
+            
+    print(f"CDN Warm up completed. Successfully warmed up {success_count}/{len(packages)} packages in CDN.")
+
+if __name__ == "__main__":
+    main()

--- a/cargo-portal/terraform/.gitignore
+++ b/cargo-portal/terraform/.gitignore
@@ -1,0 +1,14 @@
+# Local active variable files (contains private project IDs)
+*.tfvars
+*.tfvars.json
+
+# Local terraform execution state directories
+.terraform/
+.terraform.lock.hcl
+
+# State history files
+terraform.tfstate
+terraform.tfstate.backup
+
+# Telemetry and checkpoint directories
+.terraform.d/

--- a/cargo-portal/terraform/README.md
+++ b/cargo-portal/terraform/README.md
@@ -132,6 +132,22 @@ kubectl get ingress kellnr-ingress -n kellnr
 > [!NOTE]
 > It can take 5-10 minutes for the GKE HTTP(S) Load Balancer and global IP bindings to fully propagate in GCP.
 
+## 🛠️ Troubleshooting & Pitfalls
+
+### 1. GCS HMAC Credentials (Signature Errors)
+*   **Symptom**: Pod logs show `S3 error: Generic S3 error: ... Server returned non-2xx status code: 400 Bad Request` with `MalformedSecurityHeader` and `Credential scope string has invalid format`.
+*   **Cause**: 
+    *   **Resource ID vs Access ID**: The Terraform `google_storage_hmac_key` resource's `.id` attribute exports the full resource path (`projects/{{project}}/hmacKeys/{{access_id}}`). If this is mapped directly to the S3 access key, GCS signature verification fails.
+    *   **Region Scope Mismatch**: GCS S3 API expects the region in the Signature V4 credential scope to be `"US"` or `"us-east-1"` for compatibility, even if the target bucket is in a specific region like `us-central1`.
+*   **Solution**:
+    *   Ensure the access key is mapped using the `.access_id` attribute (e.g., `GOOG1ESK...`) in Terraform outputs, not `.id`.
+    *   Hardcode `KELLNR_S3__REGION` to `"US"` or `"us-east-1"` in the Kubernetes deployment environment variables when using GCS backend.
+
+### 2. Sparse Index Routing & Unexpected JSON Responses
+*   **Symptom**: Direct `curl` requests to download a crate (e.g. `/api/v1/cratesio/anyhow/1.0.80/download`) return `200 OK` but with JSON index metadata for a crate named `download` instead of the `.crate` gzip file.
+*   **Cause**: The Cargo sparse registry protocol expects a `/dl` path prefix for download requests (as defined in the index's `config.json`). If `/dl` is omitted, Kellnr matches the metadata/index routes instead. It treats the path as a package name, sanitizes it to the last segment (`download`), and returns the index metadata for that mock package.
+*   **Solution**: Always verify download endpoints using the correct path with the `/dl` segment: `/api/v1/cratesio/dl/{crate}/{version}/download`.
+
 ---
 
 ## 🗑️ Clean Up & Teardown

--- a/cargo-portal/terraform/README.md
+++ b/cargo-portal/terraform/README.md
@@ -1,0 +1,150 @@
+# Kellnr Caching Proxy & Private Registry on GKE - Terraform Deployment Lab
+
+This folder contains the 100% codified, production-ready Terraform configuration for deploying Kellnr as a Cargo caching proxy and private registry on Google Kubernetes Engine (GKE) Autopilot.
+
+This setup supports different scaling and performance options, making it ideal for GKE Lab environments, stress testing under concurrent workloads, or proof-of-concept deployments.
+
+---
+
+## 🏗️ Architecture Options
+
+The deployment supports 6 distinct modes selectable via the `deployment_option` variable. These choices map automatically to CPU/Memory sizes, database tiers, and edge caching (CDN) configurations:
+
+| Sizing & CDN Choice (`deployment_option`) | CDN Edge Cache | Storage Backend | GKE Replica Pods | Database Tier | Workload Purpose |
+| :--- | :---: | :--- | :---: | :--- | :--- |
+| **`gke_cdn_gcs`** (Default) | **Enabled** | GCS Bucket | 3 Pods (0.2 CPU) | `db-f1-micro` | Standard recommended public-facing caching proxy. |
+| **`gke_cdn_filestore`** | **Enabled** | Filestore PVC | 3 Pods (0.2 CPU) | `db-f1-micro` | CDN option using shared file system rather than GCS. |
+| **`gke_only_2node_gcs`** | Disabled | GCS Bucket | 22 Pods (4.0 CPU) | `db-n1-standard-16` | High-load internal stress test (scaled across 2 nodes). |
+| **`gke_only_2node_filestore`** | Disabled | Filestore PVC | 22 Pods (4.0 CPU) | `db-n1-standard-16` | Dynamic shared filesystem load test. |
+| **`gke_only_1node_gcs`** | Disabled | GCS Bucket | 11 Pods (4.0 CPU) | `db-n1-standard-16` | Medium-load internal stress test (contained on 1 node). |
+| **`gke_only_1node_filestore`** | Disabled | Filestore PVC | 11 Pods (4.0 CPU) | `db-n1-standard-16` | Single-node dynamic NFS load test. |
+
+---
+
+## 📁 Repository Structure
+
+The deployment is split into two phases to avoid plan-time validation errors with GKE custom resources (like GKE's `BackendConfig` and `Ingress` controllers) before the API server is live:
+
+```
+terraform/
+├── README.md               # This deployment guide
+├── infra/                  # Phase 1: GCP Infrastructure (VPC, SQL, GCS, GKE Cluster)
+│   ├── database.tf
+│   ├── filestore.tf
+│   ├── gke.tf
+│   ├── locals.tf
+│   ├── outputs.tf
+│   ├── providers.tf
+│   ├── storage.tf
+│   ├── variables.tf
+│   └── vpc.tf
+└── k8s/                    # Phase 2: Kubernetes Workloads (Deployments, Services, Ingress, Secrets)
+    ├── k8s_resources.tf
+    ├── locals.tf
+    ├── outputs.tf
+    ├── providers.tf
+    └── variables.tf
+```
+
+---
+
+## 🚀 Deployment Guide
+
+### Prerequisites
+
+1.  **GCP Identity Authentication**:
+    Ensure the `google-cloud-cli` is installed and you have authenticated both the gcloud client and your Application Default Credentials (ADC):
+    ```bash
+    gcloud auth login
+    gcloud auth application-default login
+    ```
+2.  **Target GCP Project & IAM Roles**:
+    Identify your target GCP Project ID. The authenticated identity running the deployment must have the following IAM roles on the target project to create the VPC, GKE, databases, storage, and IAM bindings:
+    *   `roles/owner` (or a combination of `roles/editor` and `roles/resourcemanager.projectIamAdmin`)
+    *   *Note*: Creating Workload Identity bindings and service account IAM bindings requires project-level IAM administration write access.
+
+
+---
+
+### Step 1: Deploy Phase 1 (GCP Infrastructure)
+
+1. Navigate to the `infra` directory:
+   ```bash
+   cd terraform/infra
+   ```
+2. Initialize Terraform:
+   ```bash
+   terraform init
+   ```
+3. Run `plan` to verify the resources to be created (replace `YOUR_PROJECT_ID` with your actual GCP Project):
+   ```bash
+   terraform plan -var="project_id=YOUR_PROJECT_ID" -var="deployment_option=gke_cdn_gcs"
+   ```
+4. Apply the configuration (this will provision the VPC, SQL Database, GCS Bucket, and GKE Autopilot cluster. This process takes **10-15 minutes**):
+   ```bash
+   terraform apply -var="project_id=YOUR_PROJECT_ID" -var="deployment_option=gke_cdn_gcs"
+   ```
+
+Upon completion, Terraform will write the details of the created resources to `terraform.tfstate`.
+
+---
+
+### Step 2: Deploy Phase 2 (Kubernetes Workloads)
+
+1. Navigate to the `k8s` directory:
+   ```bash
+   cd ../k8s
+   ```
+2. Initialize the Kubernetes provider:
+   ```bash
+   terraform init
+   ```
+   *(This initializes the Kubernetes provider using the local state outputs exported from the `infra` directory).*
+3. Deploy the Kellnr workloads:
+   ```bash
+   terraform apply
+   ```
+
+When the command completes, it will output the dynamic public Ingress Load Balancer IP address (if CDN was enabled).
+
+---
+
+## 🔍 Validation & Verification
+
+### 1. Fetch the Database Connection Password
+The SQL database password is dynamically generated at apply-time and stored securely inside a Kubernetes secret. You can retrieve it by running:
+```bash
+gcloud container clusters get-credentials kellnr-cluster --region us-central1 --project YOUR_PROJECT_ID
+kubectl get secret kellnr-secrets -n kellnr -o jsonpath="{.data.db_password}" | base64 --decode
+```
+
+### 2. Verify Workload Pod Status
+Check if the Kellnr pods are up and running:
+```bash
+kubectl get pods -n kellnr
+```
+
+### 3. Check CDN Ingress Status (GKE + CDN Option)
+Retrieve the Ingress details to monitor the load balancer provisioning status:
+```bash
+kubectl get ingress kellnr-ingress -n kellnr
+```
+> [!NOTE]
+> It can take 5-10 minutes for the GKE HTTP(S) Load Balancer and global IP bindings to fully propagate in GCP.
+
+---
+
+## 🗑️ Clean Up & Teardown
+
+To completely clean up and delete all resources created in this lab, run the destroy commands in **reverse order**:
+
+1. Destroy the Kubernetes workloads first:
+   ```bash
+   cd terraform/k8s
+   terraform destroy
+   ```
+2. Destroy the GCP Infrastructure:
+   ```bash
+   cd ../infra
+   terraform destroy -var="project_id=YOUR_PROJECT_ID" -var="deployment_option=gke_cdn_gcs"
+   ```

--- a/cargo-portal/terraform/infra/database.tf
+++ b/cargo-portal/terraform/infra/database.tf
@@ -18,10 +18,7 @@ resource "google_sql_database_instance" "kellnr_postgres" {
       ipv4_enabled = true # Required for Cloud SQL Proxy to connect over public IP securely via IAM
     }
 
-    database_flags {
-      name  = "max_connections"
-      value = "100"
-    }
+
   }
 }
 

--- a/cargo-portal/terraform/infra/database.tf
+++ b/cargo-portal/terraform/infra/database.tf
@@ -1,0 +1,32 @@
+resource "random_password" "db_password" {
+  length  = 16
+  special = false
+}
+
+resource "google_sql_database_instance" "kellnr_postgres" {
+  name             = "kellnr-postgres"
+  database_version = "POSTGRES_15"
+  region           = var.region
+
+  # Set deletion protection to false for easier teardown of the test lab environment.
+  deletion_protection = false
+
+  settings {
+    tier = local.cfg.database_tier
+
+    ip_configuration {
+      ipv4_enabled = true # Required for Cloud SQL Proxy to connect over public IP securely via IAM
+    }
+  }
+}
+
+resource "google_sql_database" "kellnr_db" {
+  name     = "kellnr_db"
+  instance = google_sql_database_instance.kellnr_postgres.name
+}
+
+resource "google_sql_user" "kellnr_user" {
+  name     = "kellnr_user"
+  instance = google_sql_database_instance.kellnr_postgres.name
+  password = random_password.db_password.result
+}

--- a/cargo-portal/terraform/infra/database.tf
+++ b/cargo-portal/terraform/infra/database.tf
@@ -17,6 +17,11 @@ resource "google_sql_database_instance" "kellnr_postgres" {
     ip_configuration {
       ipv4_enabled = true # Required for Cloud SQL Proxy to connect over public IP securely via IAM
     }
+
+    database_flags {
+      name  = "max_connections"
+      value = "100"
+    }
   }
 }
 

--- a/cargo-portal/terraform/infra/filestore.tf
+++ b/cargo-portal/terraform/infra/filestore.tf
@@ -1,0 +1,16 @@
+resource "google_filestore_instance" "kellnr_filestore" {
+  count    = local.cfg.storage_backend == "filestore" ? 1 : 0
+  name     = "kellnr-filestore"
+  location = var.zone
+  tier     = "STANDARD"
+
+  file_shares {
+    capacity_gb = 1024 # Filestore Standard tier requires a minimum of 1TiB (1024 GB)
+    name        = "vol1"
+  }
+
+  networks {
+    network = google_compute_network.kellnr_network.name
+    modes   = ["MODE_IPV4"]
+  }
+}

--- a/cargo-portal/terraform/infra/gke.tf
+++ b/cargo-portal/terraform/infra/gke.tf
@@ -1,0 +1,47 @@
+resource "google_container_cluster" "primary" {
+  name     = "kellnr-cluster"
+  location = var.region
+
+  # Enable Autopilot
+  enable_autopilot = true
+
+  network    = google_compute_network.kellnr_network.name
+  subnetwork = google_compute_subnetwork.kellnr_subnet.name
+
+  ip_allocation_policy {
+    # Autopilot manages cluster pod/services IP allocation automatically
+  }
+
+  private_cluster_config {
+    enable_private_nodes    = true
+    enable_private_endpoint = false # Keep the control plane public endpoint open so we can actuate K8s resources from the runner
+    master_ipv4_cidr_block  = "172.16.0.0/28"
+  }
+
+  # Necessary to wait for VPC and Subnets to be fully provisioned
+  depends_on = [
+    google_compute_subnetwork.kellnr_subnet,
+    google_compute_router_nat.kellnr_nat
+  ]
+}
+
+# Google Service Account (GSA) used by Kellnr pods
+resource "google_service_account" "kellnr_gsa" {
+  account_id   = "kellnr-gsa"
+  display_name = "Kellnr GKE Workload Identity Service Account"
+  project      = var.project_id
+}
+
+# Grant GSA access to connect to Cloud SQL
+resource "google_project_iam_member" "gsa_sql_client" {
+  project = var.project_id
+  role    = "roles/cloudsql.client"
+  member  = "serviceAccount:${google_service_account.kellnr_gsa.email}"
+}
+
+# Bind GSA to GKE KSA via Workload Identity User role
+resource "google_service_account_iam_member" "gsa_workload_identity" {
+  service_account_id = google_service_account.kellnr_gsa.name
+  role               = "roles/iam.workloadIdentityUser"
+  member             = "serviceAccount:${var.project_id}.svc.id.goog[kellnr/kellnr-ksa]"
+}

--- a/cargo-portal/terraform/infra/locals.tf
+++ b/cargo-portal/terraform/infra/locals.tf
@@ -1,0 +1,54 @@
+locals {
+  options = {
+    gke_cdn_gcs = {
+      enable_cdn        = true
+      storage_backend   = "gcs"
+      database_tier     = "db-f1-micro"
+      kellnr_replicas   = 3
+      kellnr_cpu        = "200m"
+      kellnr_memory     = "512Mi"
+    }
+    gke_cdn_filestore = {
+      enable_cdn        = true
+      storage_backend   = "filestore"
+      database_tier     = "db-f1-micro"
+      kellnr_replicas   = 3
+      kellnr_cpu        = "200m"
+      kellnr_memory     = "512Mi"
+    }
+    gke_only_2node_gcs = {
+      enable_cdn        = false
+      storage_backend   = "gcs"
+      database_tier     = "db-n1-standard-16"
+      kellnr_replicas   = 22
+      kellnr_cpu        = "4"
+      kellnr_memory     = "8Gi"
+    }
+    gke_only_2node_filestore = {
+      enable_cdn        = false
+      storage_backend   = "filestore"
+      database_tier     = "db-n1-standard-16"
+      kellnr_replicas   = 22
+      kellnr_cpu        = "4"
+      kellnr_memory     = "8Gi"
+    }
+    gke_only_1node_gcs = {
+      enable_cdn        = false
+      storage_backend   = "gcs"
+      database_tier     = "db-n1-standard-16"
+      kellnr_replicas   = 11
+      kellnr_cpu        = "4"
+      kellnr_memory     = "8Gi"
+    }
+    gke_only_1node_filestore = {
+      enable_cdn        = false
+      storage_backend   = "filestore"
+      database_tier     = "db-n1-standard-16"
+      kellnr_replicas   = 11
+      kellnr_cpu        = "4"
+      kellnr_memory     = "8Gi"
+    }
+  }
+
+  cfg = local.options[var.deployment_option]
+}

--- a/cargo-portal/terraform/infra/locals.tf
+++ b/cargo-portal/terraform/infra/locals.tf
@@ -3,7 +3,7 @@ locals {
     gke_cdn_gcs = {
       enable_cdn        = true
       storage_backend   = "gcs"
-      database_tier     = "db-f1-micro"
+      database_tier     = "db-custom-1-3840"
       kellnr_replicas   = 3
       kellnr_cpu        = "200m"
       kellnr_memory     = "512Mi"
@@ -11,7 +11,7 @@ locals {
     gke_cdn_filestore = {
       enable_cdn        = true
       storage_backend   = "filestore"
-      database_tier     = "db-f1-micro"
+      database_tier     = "db-custom-1-3840"
       kellnr_replicas   = 3
       kellnr_cpu        = "200m"
       kellnr_memory     = "512Mi"

--- a/cargo-portal/terraform/infra/locals.tf
+++ b/cargo-portal/terraform/infra/locals.tf
@@ -19,7 +19,7 @@ locals {
     gke_only_2node_gcs = {
       enable_cdn        = false
       storage_backend   = "gcs"
-      database_tier     = "db-n1-standard-16"
+      database_tier     = "db-custom-16-61440"
       kellnr_replicas   = 22
       kellnr_cpu        = "4"
       kellnr_memory     = "8Gi"
@@ -27,7 +27,7 @@ locals {
     gke_only_2node_filestore = {
       enable_cdn        = false
       storage_backend   = "filestore"
-      database_tier     = "db-n1-standard-16"
+      database_tier     = "db-custom-16-61440"
       kellnr_replicas   = 22
       kellnr_cpu        = "4"
       kellnr_memory     = "8Gi"
@@ -35,7 +35,7 @@ locals {
     gke_only_1node_gcs = {
       enable_cdn        = false
       storage_backend   = "gcs"
-      database_tier     = "db-n1-standard-16"
+      database_tier     = "db-custom-16-61440"
       kellnr_replicas   = 11
       kellnr_cpu        = "4"
       kellnr_memory     = "8Gi"
@@ -43,7 +43,7 @@ locals {
     gke_only_1node_filestore = {
       enable_cdn        = false
       storage_backend   = "filestore"
-      database_tier     = "db-n1-standard-16"
+      database_tier     = "db-custom-16-61440"
       kellnr_replicas   = 11
       kellnr_cpu        = "4"
       kellnr_memory     = "8Gi"

--- a/cargo-portal/terraform/infra/outputs.tf
+++ b/cargo-portal/terraform/infra/outputs.tf
@@ -1,0 +1,69 @@
+output "project_id" {
+  value = var.project_id
+}
+
+output "region" {
+  value = var.region
+}
+
+output "gke_cluster_name" {
+  value = google_container_cluster.primary.name
+}
+
+output "gke_cluster_endpoint" {
+  value = google_container_cluster.primary.endpoint
+}
+
+output "gke_cluster_ca_certificate" {
+  value = google_container_cluster.primary.master_auth[0].cluster_ca_certificate
+}
+
+output "gsa_email" {
+  value = google_service_account.kellnr_gsa.email
+}
+
+output "db_connection_name" {
+  value = "${var.project_id}:${var.region}:${google_sql_database_instance.kellnr_postgres.name}"
+}
+
+output "db_name" {
+  value = google_sql_database.kellnr_db.name
+}
+
+output "db_user" {
+  value = google_sql_user.kellnr_user.name
+}
+
+output "db_password" {
+  value     = random_password.db_password.result
+  sensitive = true
+}
+
+output "gcs_bucket_name" {
+  value = local.cfg.storage_backend == "gcs" ? google_storage_bucket.kellnr_bucket[0].name : ""
+}
+
+output "gcs_hmac_access_key_id" {
+  value = local.cfg.storage_backend == "gcs" ? google_storage_hmac_key.kellnr_hmac_key[0].id : ""
+}
+
+output "gcs_hmac_secret_key" {
+  value     = local.cfg.storage_backend == "gcs" ? google_storage_hmac_key.kellnr_hmac_key[0].secret : ""
+  sensitive = true
+}
+
+output "kellnr_static_ip_address" {
+  value = local.cfg.enable_cdn ? google_compute_global_address.kellnr_static_ip[0].address : ""
+}
+
+output "cloud_armor_policy_name" {
+  value = local.cfg.enable_cdn ? google_compute_security_policy.cloud_armor_policy[0].name : ""
+}
+
+output "cfg" {
+  value = local.cfg
+}
+
+output "kellnr_network_name" {
+  value = google_compute_network.kellnr_network.name
+}

--- a/cargo-portal/terraform/infra/outputs.tf
+++ b/cargo-portal/terraform/infra/outputs.tf
@@ -44,7 +44,7 @@ output "gcs_bucket_name" {
 }
 
 output "gcs_hmac_access_key_id" {
-  value = local.cfg.storage_backend == "gcs" ? google_storage_hmac_key.kellnr_hmac_key[0].id : ""
+  value = local.cfg.storage_backend == "gcs" ? google_storage_hmac_key.kellnr_hmac_key[0].access_id : ""
 }
 
 output "gcs_hmac_secret_key" {

--- a/cargo-portal/terraform/infra/outputs.tf
+++ b/cargo-portal/terraform/infra/outputs.tf
@@ -67,3 +67,7 @@ output "cfg" {
 output "kellnr_network_name" {
   value = google_compute_network.kellnr_network.name
 }
+
+output "kellnr_filestore_ip" {
+  value = local.cfg.storage_backend == "filestore" ? google_filestore_instance.kellnr_filestore[0].networks[0].ip_addresses[0] : ""
+}

--- a/cargo-portal/terraform/infra/providers.tf
+++ b/cargo-portal/terraform/infra/providers.tf
@@ -1,0 +1,18 @@
+terraform {
+  required_version = ">= 1.0"
+  required_providers {
+    google = {
+      source  = "hashicorp/google"
+      version = "~> 5.0"
+    }
+    random = {
+      source  = "hashicorp/random"
+      version = "~> 3.0"
+    }
+  }
+}
+
+provider "google" {
+  project = var.project_id
+  region  = var.region
+}

--- a/cargo-portal/terraform/infra/storage.tf
+++ b/cargo-portal/terraform/infra/storage.tf
@@ -1,0 +1,25 @@
+resource "random_id" "bucket_suffix" {
+  byte_length = 4
+}
+
+resource "google_storage_bucket" "kellnr_bucket" {
+  count         = local.cfg.storage_backend == "gcs" ? 1 : 0
+  name          = "kellnr-crates-${var.project_id}-${random_id.bucket_suffix.hex}"
+  location      = var.region
+  force_destroy = true # Allow cleanup of all storage objects on destroy
+
+  public_access_prevention = "enforced"
+}
+
+resource "google_storage_hmac_key" "kellnr_hmac_key" {
+  count                 = local.cfg.storage_backend == "gcs" ? 1 : 0
+  service_account_email = google_service_account.kellnr_gsa.email
+  project               = var.project_id
+}
+
+resource "google_storage_bucket_iam_member" "gsa_bucket_access" {
+  count  = local.cfg.storage_backend == "gcs" ? 1 : 0
+  bucket = google_storage_bucket.kellnr_bucket[0].name
+  role   = "roles/storage.objectAdmin"
+  member = "serviceAccount:${google_service_account.kellnr_gsa.email}"
+}

--- a/cargo-portal/terraform/infra/storage.tf
+++ b/cargo-portal/terraform/infra/storage.tf
@@ -8,7 +8,8 @@ resource "google_storage_bucket" "kellnr_bucket" {
   location      = var.region
   force_destroy = true # Allow cleanup of all storage objects on destroy
 
-  public_access_prevention = "enforced"
+  public_access_prevention    = "enforced"
+  uniform_bucket_level_access = true
 }
 
 resource "google_storage_hmac_key" "kellnr_hmac_key" {

--- a/cargo-portal/terraform/infra/terraform.tfvars.example
+++ b/cargo-portal/terraform/infra/terraform.tfvars.example
@@ -1,0 +1,14 @@
+# The GCP Project ID to deploy resources to
+project_id = "YOUR_PROJECT_ID"
+
+# The GCP region and zone for resources
+region = "us-central1"
+zone   = "us-central1-a"
+
+# Select the deployment option: 
+# Options: gke_cdn_gcs, gke_cdn_filestore, gke_only_2node_gcs, gke_only_2node_filestore, gke_only_1node_gcs, gke_only_1node_filestore
+deployment_option = "gke_cdn_gcs"
+
+# IP ranges allowed to access the Ingress Load Balancer (Cloud Armor).
+# Set to specific corporate ranges to restrict access.
+allowed_ip_ranges = ["0.0.0.0/0"]

--- a/cargo-portal/terraform/infra/variables.tf
+++ b/cargo-portal/terraform/infra/variables.tf
@@ -1,0 +1,33 @@
+variable "project_id" {
+  type        = string
+  description = "The GCP project ID to deploy resources to."
+}
+
+variable "region" {
+  type        = string
+  default     = "us-central1"
+  description = "The GCP region to deploy resources to."
+}
+
+variable "zone" {
+  type        = string
+  default     = "us-central1-a"
+  description = "The GCP zone to deploy zonal resources (like Filestore)."
+}
+
+variable "deployment_option" {
+  type        = string
+  default     = "gke_cdn_gcs"
+  description = "The deployment option to run: gke_cdn_gcs, gke_cdn_filestore, gke_only_2node_gcs, gke_only_2node_filestore, gke_only_1node_gcs, gke_only_1node_filestore"
+
+  validation {
+    condition     = contains(["gke_cdn_gcs", "gke_cdn_filestore", "gke_only_2node_gcs", "gke_only_2node_filestore", "gke_only_1node_gcs", "gke_only_1node_filestore"], var.deployment_option)
+    error_message = "Deployment option must be one of: gke_cdn_gcs, gke_cdn_filestore, gke_only_2node_gcs, gke_only_2node_filestore, gke_only_1node_gcs, gke_only_1node_filestore."
+  }
+}
+
+variable "allowed_ip_ranges" {
+  type        = list(string)
+  default     = ["0.0.0.0/0"]
+  description = "IP ranges allowed to access the Ingress. Used by Cloud Armor. Set to specific corporate ranges to restrict access."
+}

--- a/cargo-portal/terraform/infra/variables.tf
+++ b/cargo-portal/terraform/infra/variables.tf
@@ -28,6 +28,6 @@ variable "deployment_option" {
 
 variable "allowed_ip_ranges" {
   type        = list(string)
-  default     = ["0.0.0.0/0"]
+  default     = []
   description = "IP ranges allowed to access the Ingress. Used by Cloud Armor. Set to specific corporate ranges to restrict access."
 }

--- a/cargo-portal/terraform/infra/vpc.tf
+++ b/cargo-portal/terraform/infra/vpc.tf
@@ -1,0 +1,64 @@
+resource "google_compute_network" "kellnr_network" {
+  name                    = "kellnr-network"
+  auto_create_subnetworks = false
+}
+
+resource "google_compute_subnetwork" "kellnr_subnet" {
+  name                     = "kellnr-subnet"
+  ip_cidr_range            = "10.128.0.0/20"
+  network                  = google_compute_network.kellnr_network.id
+  region                   = var.region
+  private_ip_google_access = true
+}
+
+resource "google_compute_router" "kellnr_router" {
+  name    = "kellnr-router"
+  network = google_compute_network.kellnr_network.id
+  region  = var.region
+}
+
+resource "google_compute_router_nat" "kellnr_nat" {
+  name                               = "kellnr-nat"
+  router                             = google_compute_router.kellnr_router.name
+  region                             = var.region
+  nat_ip_allocate_option             = "AUTO_ONLY"
+  source_subnetwork_ip_ranges_to_nat = "ALL_SUBNETWORKS_ALL_IP_RANGES"
+}
+
+# Global Static IP for GKE Ingress (HTTPS Load Balancer)
+resource "google_compute_global_address" "kellnr_static_ip" {
+  count   = local.cfg.enable_cdn ? 1 : 0
+  name    = "kellnr-static-ip"
+  project = var.project_id
+}
+
+# Cloud Armor Policy to protect Load Balancer Edge
+resource "google_compute_security_policy" "cloud_armor_policy" {
+  count   = local.cfg.enable_cdn ? 1 : 0
+  name    = "kellnr-security-policy"
+  project = var.project_id
+
+  rule {
+    action   = "allow"
+    priority = "1000"
+    match {
+      versioned_expr = "SRC_IPS_V1"
+      config {
+        src_ip_ranges = var.allowed_ip_ranges
+      }
+    }
+    description = "Allow access from approved ranges"
+  }
+
+  rule {
+    action   = "deny(403)"
+    priority = "2147483647"
+    match {
+      versioned_expr = "SRC_IPS_V1"
+      config {
+        src_ip_ranges = ["*"]
+      }
+    }
+    description = "Default deny rule"
+  }
+}

--- a/cargo-portal/terraform/infra/vpc.tf
+++ b/cargo-portal/terraform/infra/vpc.tf
@@ -17,11 +17,17 @@ resource "google_compute_router" "kellnr_router" {
   region  = var.region
 }
 
+resource "google_compute_address" "nat_ip" {
+  name   = "kellnr-nat-ip"
+  region = var.region
+}
+
 resource "google_compute_router_nat" "kellnr_nat" {
   name                               = "kellnr-nat"
   router                             = google_compute_router.kellnr_router.name
   region                             = var.region
-  nat_ip_allocate_option             = "AUTO_ONLY"
+  nat_ip_allocate_option             = "MANUAL_ONLY"
+  nat_ips                            = [google_compute_address.nat_ip.self_link]
   source_subnetwork_ip_ranges_to_nat = "ALL_SUBNETWORKS_ALL_IP_RANGES"
 }
 
@@ -44,10 +50,10 @@ resource "google_compute_security_policy" "cloud_armor_policy" {
     match {
       versioned_expr = "SRC_IPS_V1"
       config {
-        src_ip_ranges = var.allowed_ip_ranges
+        src_ip_ranges = concat(["${google_compute_address.nat_ip.address}/32"], var.allowed_ip_ranges)
       }
     }
-    description = "Allow access from approved ranges"
+    description = "Allow access from approved ranges and Cloud NAT"
   }
 
   rule {

--- a/cargo-portal/terraform/k8s/k8s_resources.tf
+++ b/cargo-portal/terraform/k8s/k8s_resources.tf
@@ -176,7 +176,8 @@ resource "kubernetes_deployment" "kellnr_deployment" {
       }
       spec {
         node_selector = {
-          "topology.kubernetes.io/zone" = "us-central1-a"
+          "topology.kubernetes.io/zone"     = "us-central1-a"
+          "cloud.google.com/machine-family" = "n2"
         }
         service_account_name = kubernetes_service_account.kellnr_ksa.metadata[0].name
 
@@ -260,7 +261,7 @@ resource "kubernetes_deployment" "kellnr_deployment" {
           }
           env {
             name  = "KELLNR_REGISTRY__MAX_DB_CONNECTIONS"
-            value = "30"
+            value = "100"
           }
           env {
             name  = "KELLNR_LOG__LEVEL"
@@ -350,8 +351,8 @@ resource "kubernetes_deployment" "kellnr_deployment" {
 
           resources {
             limits = {
-              cpu    = "1"
-              memory = "2Gi"
+              cpu    = local.cfg.kellnr_cpu
+              memory = local.cfg.kellnr_memory
             }
             requests = {
               cpu    = local.cfg.kellnr_cpu

--- a/cargo-portal/terraform/k8s/k8s_resources.tf
+++ b/cargo-portal/terraform/k8s/k8s_resources.tf
@@ -175,6 +175,9 @@ resource "kubernetes_deployment" "kellnr_deployment" {
         }
       }
       spec {
+        node_selector = {
+          "topology.kubernetes.io/zone" = "us-central1-a"
+        }
         service_account_name = kubernetes_service_account.kellnr_ksa.metadata[0].name
 
         # 1. Kellnr Container

--- a/cargo-portal/terraform/k8s/k8s_resources.tf
+++ b/cargo-portal/terraform/k8s/k8s_resources.tf
@@ -1,0 +1,363 @@
+# Namespace for Kellnr deployment
+resource "kubernetes_namespace" "kellnr" {
+  metadata {
+    name = "kellnr"
+  }
+}
+
+# Kubernetes Service Account mapped to Google Service Account via Workload Identity
+resource "kubernetes_service_account" "kellnr_ksa" {
+  metadata {
+    name      = "kellnr-ksa"
+    namespace = kubernetes_namespace.kellnr.metadata[0].name
+    annotations = {
+      "iam.gke.io/gcp-service-account" = data.terraform_remote_state.infra.outputs.gsa_email
+    }
+  }
+}
+
+# Secrets store for DB connection password and GCS HMAC credentials
+resource "kubernetes_secret" "kellnr_secrets" {
+  metadata {
+    name      = "kellnr-secrets"
+    namespace = kubernetes_namespace.kellnr.metadata[0].name
+  }
+
+  type = "Opaque"
+
+  data = {
+    db_password         = data.terraform_remote_state.infra.outputs.db_password
+    gcs_hmac_access_key = data.terraform_remote_state.infra.outputs.gcs_hmac_access_key_id
+    gcs_hmac_secret_key = data.terraform_remote_state.infra.outputs.gcs_hmac_secret_key
+  }
+}
+
+# Custom GKE BackendConfig CRD to enable CDN and Cloud Armor on the Load Balancer
+resource "kubernetes_manifest" "kellnr_backend_config" {
+  count = local.cfg.enable_cdn ? 1 : 0
+
+  manifest = {
+    apiVersion = "cloud.google.com/v1"
+    kind       = "BackendConfig"
+    metadata = {
+      name      = "kellnr-backend-config"
+      namespace = kubernetes_namespace.kellnr.metadata[0].name
+    }
+    spec = {
+      cdn = {
+        enabled      = true
+        cacheMode    = "FORCE_CACHE_ALL"
+        defaultTtl   = 300
+        clientTtl    = 300
+        cachePolicy = {
+          includeHost        = true
+          includeProtocol    = true
+          includeQueryString = false
+        }
+      }
+      securityPolicy = {
+        name = data.terraform_remote_state.infra.outputs.cloud_armor_policy_name
+      }
+    }
+  }
+}
+
+# Storage Class for Filestore PVC
+resource "kubernetes_storage_class" "filestore_sc" {
+  count = local.cfg.storage_backend == "filestore" ? 1 : 0
+  metadata {
+    name = "kellnr-filestore-sc"
+  }
+  storage_provisioner = "filestore.csi.storage.gke.io"
+  volume_binding_mode = "WaitForFirstConsumer"
+  parameters = {
+    tier    = "standard"
+    network = data.terraform_remote_state.infra.outputs.kellnr_network_name
+  }
+}
+
+# PVC for Filestore dynamic provisioning
+resource "kubernetes_persistent_volume_claim" "filestore_pvc" {
+  count = local.cfg.storage_backend == "filestore" ? 1 : 0
+  metadata {
+    name      = "kellnr-storage-pvc"
+    namespace = kubernetes_namespace.kellnr.metadata[0].name
+  }
+  spec {
+    access_modes       = ["ReadWriteMany"]
+    storage_class_name = kubernetes_storage_class.filestore_sc[0].metadata[0].name
+    resources {
+      requests = {
+        storage = "1Ti" # Filestore requires minimum 1Ti
+      }
+    }
+  }
+}
+
+# Kellnr Service (NodePort required for GKE Ingress integration)
+resource "kubernetes_service" "kellnr_service" {
+  metadata {
+    name      = "kellnr-service"
+    namespace = kubernetes_namespace.kellnr.metadata[0].name
+    annotations = local.cfg.enable_cdn ? {
+      "cloud.google.com/backend-config" = jsonencode({ "default" = "kellnr-backend-config" })
+    } : {}
+  }
+  spec {
+    selector = {
+      app = "kellnr"
+    }
+    port {
+      port        = local.cfg.enable_cdn ? 80 : 8000
+      target_port = 8000
+      protocol    = "TCP"
+    }
+    type = "NodePort"
+  }
+}
+
+# Kellnr Ingress (Global Load Balancer) - only deployed if CDN is enabled
+resource "kubernetes_ingress_v1" "kellnr_ingress" {
+  count = local.cfg.enable_cdn ? 1 : 0
+  metadata {
+    name      = "kellnr-ingress"
+    namespace = kubernetes_namespace.kellnr.metadata[0].name
+    annotations = {
+      "kubernetes.io/ingress.global-static-ip-name" = "kellnr-static-ip"
+      "kubernetes.io/ingress.class"                 = "gce"
+    }
+  }
+  spec {
+    default_backend {
+      service {
+        name = kubernetes_service.kellnr_service.metadata[0].name
+        port {
+          number = 80
+        }
+      }
+    }
+  }
+}
+
+# Kellnr Core Workload Deployment
+resource "kubernetes_deployment" "kellnr_deployment" {
+  metadata {
+    name      = "kellnr-deployment"
+    namespace = kubernetes_namespace.kellnr.metadata[0].name
+    labels = {
+      app = "kellnr"
+    }
+  }
+  spec {
+    replicas = local.cfg.kellnr_replicas
+    selector {
+      match_labels = {
+        app = "kellnr"
+      }
+    }
+    template {
+      metadata {
+        labels = {
+          app = "kellnr"
+        }
+      }
+      spec {
+        service_account_name = kubernetes_service_account.kellnr_ksa.metadata[0].name
+
+        # 1. Kellnr Container
+        container {
+          name  = "kellnr"
+          image = "ghcr.io/kellnr/kellnr:5"
+
+          port {
+            container_port = 8000
+          }
+
+          env {
+            name  = "KELLNR_PROXY__ENABLED"
+            value = "true"
+          }
+
+          env {
+            name  = "KELLNR_OAUTH2__ENABLED"
+            value = var.enable_oauth2 ? "true" : "false"
+          }
+          env {
+            name  = "KELLNR_OAUTH2__ISSUER"
+            value = var.kellnr_oauth2_issuer
+          }
+          env {
+            name  = "KELLNR_OAUTH2__CLIENT_ID"
+            value = var.kellnr_oauth2_client_id
+          }
+          env {
+            name  = "KELLNR_OAUTH2__CLIENT_SECRET"
+            value = var.kellnr_oauth2_client_secret
+          }
+
+          env {
+            name  = "KELLNR_POSTGRESQL__ENABLED"
+            value = "true"
+          }
+          env {
+            name  = "KELLNR_POSTGRESQL__ADDRESS"
+            value = "127.0.0.1"
+          }
+          env {
+            name  = "KELLNR_POSTGRESQL__PORT"
+            value = "5432"
+          }
+          env {
+            name  = "KELLNR_POSTGRESQL__DB"
+            value = data.terraform_remote_state.infra.outputs.db_name
+          }
+          env {
+            name  = "KELLNR_POSTGRESQL__USER"
+            value = data.terraform_remote_state.infra.outputs.db_user
+          }
+          env {
+            name = "KELLNR_POSTGRESQL__PWD"
+            value_from {
+              secret_key_ref {
+                name = kubernetes_secret.kellnr_secrets.metadata[0].name
+                key  = "db_password"
+              }
+            }
+          }
+
+          env {
+            name  = "KELLNR_ORIGIN__HOSTNAME"
+            value = local.cfg.enable_cdn ? data.terraform_remote_state.infra.outputs.kellnr_static_ip_address : "kellnr-service.kellnr.svc.cluster.local"
+          }
+          env {
+            name  = "KELLNR_ORIGIN__PORT"
+            value = local.cfg.enable_cdn ? "80" : "8000"
+          }
+          env {
+            name  = "KELLNR_ORIGIN__HTTPS"
+            value = "false"
+          }
+
+          env {
+            name  = "KELLNR_REGISTRY__DATA_DIR"
+            value = "/data"
+          }
+          env {
+            name  = "RUST_LOG"
+            value = "debug,kellnr=debug"
+          }
+
+          # GCS bucket storage S3 compatible env injection
+          dynamic "env" {
+            for_each = local.cfg.storage_backend == "gcs" ? [1] : []
+            content {
+              name  = "KELLNR_STORAGE__TYPE"
+              value = "s3"
+            }
+          }
+          dynamic "env" {
+            for_each = local.cfg.storage_backend == "gcs" ? [1] : []
+            content {
+              name  = "KELLNR_STORAGE__S3__BUCKET"
+              value = data.terraform_remote_state.infra.outputs.gcs_bucket_name
+            }
+          }
+          dynamic "env" {
+            for_each = local.cfg.storage_backend == "gcs" ? [1] : []
+            content {
+              name = "KELLNR_STORAGE__S3__ACCESS_KEY"
+              value_from {
+                secret_key_ref {
+                  name = kubernetes_secret.kellnr_secrets.metadata[0].name
+                  key  = "gcs_hmac_access_key"
+                }
+              }
+            }
+          }
+          dynamic "env" {
+            for_each = local.cfg.storage_backend == "gcs" ? [1] : []
+            content {
+              name = "KELLNR_STORAGE__S3__SECRET_KEY"
+              value_from {
+                secret_key_ref {
+                  name = kubernetes_secret.kellnr_secrets.metadata[0].name
+                  key  = "gcs_hmac_secret_key"
+                }
+              }
+            }
+          }
+          dynamic "env" {
+            for_each = local.cfg.storage_backend == "gcs" ? [1] : []
+            content {
+              name  = "KELLNR_STORAGE__S3__ENDPOINT"
+              value = "https://storage.googleapis.com"
+            }
+          }
+          dynamic "env" {
+            for_each = local.cfg.storage_backend == "gcs" ? [1] : []
+            content {
+              name  = "KELLNR_STORAGE__S3__REGION"
+              value = data.terraform_remote_state.infra.outputs.region
+            }
+          }
+
+          volume_mount {
+            name       = "kellnr-storage-volume"
+            mount_path = "/data"
+          }
+
+          resources {
+            limits = {
+              cpu    = "1"
+              memory = "2Gi"
+            }
+            requests = {
+              cpu    = local.cfg.kellnr_cpu
+              memory = local.cfg.kellnr_memory
+            }
+          }
+        }
+
+        # 2. Cloud SQL Proxy Sidecar
+        container {
+          name  = "cloud-sql-proxy"
+          image = "gcr.io/cloud-sql-connectors/cloud-sql-proxy:2.1.0"
+          args = [
+            data.terraform_remote_state.infra.outputs.db_connection_name,
+            "--port=5432"
+          ]
+          security_context {
+            run_as_non_root = true
+          }
+          resources {
+            limits = {
+              cpu    = "500m"
+              memory = "512Mi"
+            }
+            requests = {
+              cpu    = "100m"
+              memory = "128Mi"
+            }
+          }
+        }
+
+        # Mount dynamic volume backing (PVC or emptyDir)
+        volume {
+          name = "kellnr-storage-volume"
+
+          dynamic "persistent_volume_claim" {
+            for_each = local.cfg.storage_backend == "filestore" ? [1] : []
+            content {
+              claim_name = kubernetes_persistent_volume_claim.filestore_pvc[0].metadata[0].name
+            }
+          }
+
+          dynamic "empty_dir" {
+            for_each = local.cfg.storage_backend == "gcs" ? [1] : []
+            content {}
+          }
+        }
+      }
+    }
+  }
+}

--- a/cargo-portal/terraform/k8s/k8s_resources.tf
+++ b/cargo-portal/terraform/k8s/k8s_resources.tf
@@ -118,7 +118,7 @@ resource "kubernetes_service" "kellnr_service" {
       app = "kellnr"
     }
     port {
-      port        = local.cfg.enable_cdn ? 80 : 8000
+      port        = 80
       target_port = 8000
       protocol    = "TCP"
     }

--- a/cargo-portal/terraform/k8s/k8s_resources.tf
+++ b/cargo-portal/terraform/k8s/k8s_resources.tf
@@ -62,21 +62,28 @@ resource "kubernetes_manifest" "kellnr_backend_config" {
   }
 }
 
-# Storage Class for Filestore PVC
-resource "kubernetes_storage_class" "filestore_sc" {
+# Statically mapped PV referencing the pre-created Filestore instance in Phase 1
+resource "kubernetes_persistent_volume" "filestore_pv" {
   count = local.cfg.storage_backend == "filestore" ? 1 : 0
   metadata {
-    name = "kellnr-filestore-sc"
+    name = "kellnr-filestore-pv"
   }
-  storage_provisioner = "filestore.csi.storage.gke.io"
-  volume_binding_mode = "WaitForFirstConsumer"
-  parameters = {
-    tier    = "standard"
-    network = data.terraform_remote_state.infra.outputs.kellnr_network_name
+  spec {
+    capacity = {
+      storage = "1Ti"
+    }
+    access_modes = ["ReadWriteMany"]
+    persistent_volume_source {
+      nfs {
+        path   = "/vol1"
+        server = data.terraform_remote_state.infra.outputs.kellnr_filestore_ip
+      }
+    }
+    storage_class_name = "kellnr-filestore-static"
   }
 }
 
-# PVC for Filestore dynamic provisioning
+# PVC bound to the static PersistentVolume
 resource "kubernetes_persistent_volume_claim" "filestore_pvc" {
   count = local.cfg.storage_backend == "filestore" ? 1 : 0
   metadata {
@@ -85,13 +92,15 @@ resource "kubernetes_persistent_volume_claim" "filestore_pvc" {
   }
   spec {
     access_modes       = ["ReadWriteMany"]
-    storage_class_name = kubernetes_storage_class.filestore_sc[0].metadata[0].name
+    storage_class_name = "kellnr-filestore-static"
+    volume_name        = kubernetes_persistent_volume.filestore_pv[0].metadata[0].name
     resources {
       requests = {
-        storage = "1Ti" # Filestore requires minimum 1Ti
+        storage = "1Ti"
       }
     }
   }
+  wait_until_bound = false
 }
 
 # Kellnr Service (NodePort required for GKE Ingress integration)
@@ -101,6 +110,7 @@ resource "kubernetes_service" "kellnr_service" {
     namespace = kubernetes_namespace.kellnr.metadata[0].name
     annotations = local.cfg.enable_cdn ? {
       "cloud.google.com/backend-config" = jsonencode({ "default" = "kellnr-backend-config" })
+      "cloud.google.com/neg"            = jsonencode({ "ingress" = true })
     } : {}
   }
   spec {
@@ -122,6 +132,9 @@ resource "kubernetes_ingress_v1" "kellnr_ingress" {
   metadata {
     name      = "kellnr-ingress"
     namespace = kubernetes_namespace.kellnr.metadata[0].name
+    labels = {
+      "force-reconcile" = "1"
+    }
     annotations = {
       "kubernetes.io/ingress.global-static-ip-name" = "kellnr-static-ip"
       "kubernetes.io/ingress.class"                 = "gce"

--- a/cargo-portal/terraform/k8s/k8s_resources.tf
+++ b/cargo-portal/terraform/k8s/k8s_resources.tf
@@ -256,29 +256,48 @@ resource "kubernetes_deployment" "kellnr_deployment" {
             value = "/data"
           }
           env {
-            name  = "RUST_LOG"
-            value = "debug,kellnr=debug"
+            name  = "KELLNR_REGISTRY__MAX_DB_CONNECTIONS"
+            value = "30"
+          }
+          env {
+            name  = "KELLNR_LOG__LEVEL"
+            value = "trace"
+          }
+          env {
+            name  = "KELLNR_LOG__LEVEL_WEB_SERVER"
+            value = "trace"
+          }
+          env {
+            name  = "RUST_BACKTRACE"
+            value = "1"
           }
 
           # GCS bucket storage S3 compatible env injection
           dynamic "env" {
             for_each = local.cfg.storage_backend == "gcs" ? [1] : []
             content {
-              name  = "KELLNR_STORAGE__TYPE"
-              value = "s3"
+              name  = "KELLNR_S3__ENABLED"
+              value = "true"
             }
           }
           dynamic "env" {
             for_each = local.cfg.storage_backend == "gcs" ? [1] : []
             content {
-              name  = "KELLNR_STORAGE__S3__BUCKET"
+              name  = "KELLNR_S3__CRATES_BUCKET"
               value = data.terraform_remote_state.infra.outputs.gcs_bucket_name
             }
           }
           dynamic "env" {
             for_each = local.cfg.storage_backend == "gcs" ? [1] : []
             content {
-              name = "KELLNR_STORAGE__S3__ACCESS_KEY"
+              name  = "KELLNR_S3__CRATESIO_BUCKET"
+              value = data.terraform_remote_state.infra.outputs.gcs_bucket_name
+            }
+          }
+          dynamic "env" {
+            for_each = local.cfg.storage_backend == "gcs" ? [1] : []
+            content {
+              name = "KELLNR_S3__ACCESS_KEY"
               value_from {
                 secret_key_ref {
                   name = kubernetes_secret.kellnr_secrets.metadata[0].name
@@ -290,7 +309,7 @@ resource "kubernetes_deployment" "kellnr_deployment" {
           dynamic "env" {
             for_each = local.cfg.storage_backend == "gcs" ? [1] : []
             content {
-              name = "KELLNR_STORAGE__S3__SECRET_KEY"
+              name = "KELLNR_S3__SECRET_KEY"
               value_from {
                 secret_key_ref {
                   name = kubernetes_secret.kellnr_secrets.metadata[0].name
@@ -302,15 +321,22 @@ resource "kubernetes_deployment" "kellnr_deployment" {
           dynamic "env" {
             for_each = local.cfg.storage_backend == "gcs" ? [1] : []
             content {
-              name  = "KELLNR_STORAGE__S3__ENDPOINT"
+              name  = "KELLNR_S3__ENDPOINT"
               value = "https://storage.googleapis.com"
             }
           }
           dynamic "env" {
             for_each = local.cfg.storage_backend == "gcs" ? [1] : []
             content {
-              name  = "KELLNR_STORAGE__S3__REGION"
-              value = data.terraform_remote_state.infra.outputs.region
+              name  = "KELLNR_S3__REGION"
+              value = "US"
+            }
+          }
+          dynamic "env" {
+            for_each = local.cfg.storage_backend == "gcs" ? [1] : []
+            content {
+              name  = "KELLNR_S3__ALLOW_HTTP"
+              value = "false"
             }
           }
 

--- a/cargo-portal/terraform/k8s/locals.tf
+++ b/cargo-portal/terraform/k8s/locals.tf
@@ -1,0 +1,3 @@
+locals {
+  cfg = data.terraform_remote_state.infra.outputs.cfg
+}

--- a/cargo-portal/terraform/k8s/outputs.tf
+++ b/cargo-portal/terraform/k8s/outputs.tf
@@ -1,0 +1,20 @@
+output "kellnr_ingress_ip" {
+  value       = local.cfg.enable_cdn ? data.terraform_remote_state.infra.outputs.kellnr_static_ip_address : "N/A"
+  description = "The public Ingress Load Balancer IP address."
+}
+
+output "instruction_steps" {
+  value = <<EOF
+
+Workload deployment initiated!
+
+Active Option: ${data.terraform_remote_state.infra.outputs.cfg.enable_cdn ? "GKE + CDN" : "GKE-Only Internal"}
+Storage Backend: ${data.terraform_remote_state.infra.outputs.cfg.storage_backend == "gcs" ? "Cloud Storage (GCS Bucket)" : "Cloud Filestore (NFS PVC)"}
+
+Next steps:
+${data.terraform_remote_state.infra.outputs.cfg.enable_cdn ? "1. Access Kellnr Caching Proxy from your local Cargo client at: http://${data.terraform_remote_state.infra.outputs.kellnr_static_ip_address}/" : "1. The deployment is internal-only. You can verify it by running the stress generator Job within GKE."}
+2. Retrieve the dynamically generated DB password using kubectl:
+   kubectl get secret kellnr-secrets -n kellnr -o jsonpath="{.data.db_password}" | base64 --decode
+EOF
+  description = "Post-deployment instructions."
+}

--- a/cargo-portal/terraform/k8s/providers.tf
+++ b/cargo-portal/terraform/k8s/providers.tf
@@ -1,0 +1,30 @@
+terraform {
+  required_version = ">= 1.0"
+  required_providers {
+    google = {
+      source  = "hashicorp/google"
+      version = "~> 5.0"
+    }
+    kubernetes = {
+      source  = "hashicorp/kubernetes"
+      version = "~> 2.0"
+    }
+  }
+}
+
+data "terraform_remote_state" "infra" {
+  backend = "local"
+
+  config = {
+    path = "${path.module}/../infra/terraform.tfstate"
+  }
+}
+
+data "google_client_config" "default" {}
+
+# Dynamically configure the Kubernetes provider using remote state outputs of the applied infra module
+provider "kubernetes" {
+  host                   = "https://${data.terraform_remote_state.infra.outputs.gke_cluster_endpoint}"
+  token                  = data.google_client_config.default.access_token
+  cluster_ca_certificate = base64decode(data.terraform_remote_state.infra.outputs.gke_cluster_ca_certificate)
+}

--- a/cargo-portal/terraform/k8s/variables.tf
+++ b/cargo-portal/terraform/k8s/variables.tf
@@ -1,0 +1,23 @@
+variable "enable_oauth2" {
+  type        = bool
+  default     = false
+  description = "Enable Google OIDC OAuth2 authentication in Kellnr."
+}
+
+variable "kellnr_oauth2_client_id" {
+  type        = string
+  default     = "dummy-client-id"
+  description = "Google OAuth2 Client ID (required if enable_oauth2 is true)."
+}
+
+variable "kellnr_oauth2_client_secret" {
+  type        = string
+  default     = "dummy-client-secret"
+  description = "Google OAuth2 Client Secret (required if enable_oauth2 is true)."
+}
+
+variable "kellnr_oauth2_issuer" {
+  type        = string
+  default     = "https://accounts.google.com"
+  description = "The OIDC issuer URL."
+}

--- a/cargo-portal/terraform/load-test/load_test.tf
+++ b/cargo-portal/terraform/load-test/load_test.tf
@@ -35,9 +35,10 @@ resource "kubernetes_job" "kellnr_stress_job" {
       spec {
         restart_policy       = "OnFailure"
         service_account_name = "kellnr-ksa"
-        node_selector = {
-          "topology.kubernetes.io/zone" = "us-central1-a"
-        }
+        node_selector = merge(
+          { "topology.kubernetes.io/zone" = "us-central1-a" },
+          var.node_selector
+        )
 
         container {
           name    = "load-generator"
@@ -45,15 +46,54 @@ resource "kubernetes_job" "kellnr_stress_job" {
           command = ["/bin/bash", "-c"]
           args    = [
             <<-EOT
-            until gsutil ls gs://${google_storage_bucket.load_test_bucket.name}/ >/dev/null 2>&1; do
+            cat << 'EOF' > /tmp/gcs_helper.py
+            import sys, urllib.request, json, os, urllib.parse
+            def get_token():
+                req = urllib.request.Request("http://metadata.google.internal/computeMetadata/v1/instance/service-accounts/default/token", headers={"Metadata-Flavor": "Google"})
+                return json.loads(urllib.request.urlopen(req).read())["access_token"]
+            def download(bucket, object_path, dest_path):
+                token = get_token()
+                encoded_path = urllib.parse.quote(object_path, safe='')
+                url = f"https://storage.googleapis.com/download/storage/v1/b/{bucket}/o/{encoded_path}?alt=media"
+                req = urllib.request.Request(url, headers={"Authorization": f"Bearer {token}"})
+                with urllib.request.urlopen(req) as response:
+                    with open(dest_path, "wb") as f:
+                        f.write(response.read())
+            def upload(bucket, src_path, object_path):
+                token = get_token()
+                encoded_path = urllib.parse.quote(object_path, safe='')
+                url = f"https://storage.googleapis.com/upload/storage/v1/b/{bucket}/o?uploadType=media&name={encoded_path}"
+                with open(src_path, "rb") as f:
+                    data = f.read()
+                req = urllib.request.Request(url, data=data, headers={"Authorization": f"Bearer {token}", "Content-Type": "application/octet-stream"}, method="POST")
+                with urllib.request.urlopen(req) as response:
+                    pass
+            def check(bucket):
+                try:
+                    token = get_token()
+                    url = f"https://storage.googleapis.com/storage/v1/b/{bucket}/o?maxResults=1"
+                    req = urllib.request.Request(url, headers={"Authorization": f"Bearer {token}"})
+                    with urllib.request.urlopen(req) as response:
+                        pass
+                    return True
+                except Exception as e:
+                    return False
+            if __name__ == "__main__":
+                cmd, bucket = sys.argv[1], sys.argv[2]
+                if cmd == "download": download(bucket, sys.argv[3], sys.argv[4])
+                elif cmd == "upload": upload(bucket, sys.argv[3], sys.argv[4])
+                elif cmd == "check": sys.exit(0 if check(bucket) else 1)
+            EOF
+
+            until python3 /tmp/gcs_helper.py check ${google_storage_bucket.load_test_bucket.name}; do
               echo "Waiting for Workload Identity credentials..."
               sleep 5
             done
-            gsutil cp gs://${google_storage_bucket.load_test_bucket.name}/stress-test /tmp/stress-test
-            gsutil cp gs://${google_storage_bucket.load_test_bucket.name}/packages.txt /tmp/packages.txt
+            python3 /tmp/gcs_helper.py download ${google_storage_bucket.load_test_bucket.name} stress-test /tmp/stress-test
+            python3 /tmp/gcs_helper.py download ${google_storage_bucket.load_test_bucket.name} packages.txt /tmp/packages.txt
             chmod +x /tmp/stress-test
             /tmp/stress-test
-            gsutil cp /tmp/stress_test_result.csv gs://${google_storage_bucket.load_test_bucket.name}/results/stress_test_$${POD_NAME}.csv
+            python3 /tmp/gcs_helper.py upload ${google_storage_bucket.load_test_bucket.name} /tmp/stress_test_result.csv results/stress_test_$${POD_NAME}.csv
             EOT
           ]
 

--- a/cargo-portal/terraform/load-test/load_test.tf
+++ b/cargo-portal/terraform/load-test/load_test.tf
@@ -42,6 +42,10 @@ resource "kubernetes_job" "kellnr_stress_job" {
           command = ["/bin/bash", "-c"]
           args    = [
             <<-EOT
+            until gsutil ls gs://${google_storage_bucket.load_test_bucket.name}/ >/dev/null 2>&1; do
+              echo "Waiting for Workload Identity credentials..."
+              sleep 5
+            done
             gsutil cp gs://${google_storage_bucket.load_test_bucket.name}/stress-test /tmp/stress-test
             gsutil cp gs://${google_storage_bucket.load_test_bucket.name}/packages.txt /tmp/packages.txt
             chmod +x /tmp/stress-test

--- a/cargo-portal/terraform/load-test/load_test.tf
+++ b/cargo-portal/terraform/load-test/load_test.tf
@@ -35,10 +35,24 @@ resource "kubernetes_job" "kellnr_stress_job" {
       spec {
         restart_policy       = "OnFailure"
         service_account_name = "kellnr-ksa"
-        node_selector = merge(
-          { "topology.kubernetes.io/zone" = "us-central1-a" },
-          var.node_selector
-        )
+        node_selector = var.node_selector
+
+        affinity {
+          pod_anti_affinity {
+            required_during_scheduling_ignored_during_execution {
+              label_selector {
+                match_expressions {
+                  key      = "app"
+                  operator = "In"
+                  values   = ["kellnr-stress", "kellnr"]
+                }
+              }
+              topology_key = "kubernetes.io/hostname"
+            }
+          }
+        }
+
+
 
         container {
           name    = "load-generator"

--- a/cargo-portal/terraform/load-test/load_test.tf
+++ b/cargo-portal/terraform/load-test/load_test.tf
@@ -84,6 +84,11 @@ resource "kubernetes_job" "kellnr_stress_job" {
           }
 
           env {
+            name  = "REGISTRY_PATH"
+            value = var.registry_path
+          }
+
+          env {
             name  = "CSV_OUT"
             value = "/data/stress_test_option_b_$(POD_NAME).csv"
           }

--- a/cargo-portal/terraform/load-test/load_test.tf
+++ b/cargo-portal/terraform/load-test/load_test.tf
@@ -1,0 +1,110 @@
+resource "kubernetes_pod" "kellnr_helper" {
+  metadata {
+    name      = "kellnr-helper"
+    namespace = "kellnr"
+  }
+
+  spec {
+    volume {
+      name = "kellnr-storage-volume"
+      persistent_volume_claim {
+        claim_name = "kellnr-storage-pvc"
+      }
+    }
+
+    container {
+      name    = "helper"
+      image   = "ubuntu:22.04"
+      command = ["sleep", "3600"]
+
+      volume_mount {
+        name       = "kellnr-storage-volume"
+        mount_path = "/data"
+      }
+    }
+  }
+}
+
+resource "kubernetes_job" "kellnr_stress_job" {
+  metadata {
+    name      = "kellnr-stress-job"
+    namespace = "kellnr"
+  }
+
+  spec {
+    parallelism = var.parallelism
+    completions = var.completions
+    backoff_limit = 0
+
+    template {
+      metadata {
+        labels = {
+          app = "kellnr-stress"
+        }
+      }
+
+      spec {
+        restart_policy = "Never"
+
+        volume {
+          name = "kellnr-storage-volume"
+          persistent_volume_claim {
+            claim_name = "kellnr-storage-pvc"
+          }
+        }
+
+        container {
+          name    = "load-generator"
+          image   = "ubuntu:22.04"
+          command = ["/bin/bash", "-c"]
+          args    = ["chmod +x /data/stress-test && /data/stress-test"]
+
+          env {
+            name  = "GKE_IP"
+            value = data.terraform_remote_state.infra.outputs.kellnr_static_ip_address
+          }
+
+          env {
+            name  = "CONCURRENCY"
+            value = tostring(var.concurrency)
+          }
+
+          env {
+            name  = "DURATION"
+            value = tostring(var.duration)
+          }
+
+          env {
+            name = "POD_NAME"
+            value_from {
+              field_ref {
+                field_path = "metadata.name"
+              }
+            }
+          }
+
+          env {
+            name  = "CSV_OUT"
+            value = "/data/stress_test_option_b_$(POD_NAME).csv"
+          }
+
+          volume_mount {
+            name       = "kellnr-storage-volume"
+            mount_path = "/data"
+          }
+
+          resources {
+            limits = {
+              cpu    = "2"
+              memory = "2Gi"
+            }
+            requests = {
+              cpu    = "500m"
+              memory = "512Mi"
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/cargo-portal/terraform/load-test/load_test.tf
+++ b/cargo-portal/terraform/load-test/load_test.tf
@@ -35,6 +35,9 @@ resource "kubernetes_job" "kellnr_stress_job" {
       spec {
         restart_policy       = "OnFailure"
         service_account_name = "kellnr-ksa"
+        node_selector = {
+          "topology.kubernetes.io/zone" = "us-central1-a"
+        }
 
         container {
           name    = "load-generator"

--- a/cargo-portal/terraform/load-test/load_test.tf
+++ b/cargo-portal/terraform/load-test/load_test.tf
@@ -23,7 +23,7 @@ resource "kubernetes_job" "kellnr_stress_job" {
   spec {
     parallelism   = var.parallelism
     completions   = var.completions
-    backoff_limit = 0
+    backoff_limit = 3
 
     template {
       metadata {
@@ -33,7 +33,7 @@ resource "kubernetes_job" "kellnr_stress_job" {
       }
 
       spec {
-        restart_policy       = "Never"
+        restart_policy       = "OnFailure"
         service_account_name = "kellnr-ksa"
 
         container {
@@ -52,7 +52,7 @@ resource "kubernetes_job" "kellnr_stress_job" {
 
           env {
             name  = "GKE_IP"
-            value = data.terraform_remote_state.infra.outputs.kellnr_static_ip_address
+            value = data.terraform_remote_state.infra.outputs.cfg.enable_cdn ? data.terraform_remote_state.infra.outputs.kellnr_static_ip_address : "kellnr-service.kellnr.svc.cluster.local"
           }
 
           env {

--- a/cargo-portal/terraform/load-test/load_test.tf
+++ b/cargo-portal/terraform/load-test/load_test.tf
@@ -1,39 +1,28 @@
-resource "kubernetes_pod" "kellnr_helper" {
-  metadata {
-    name      = "kellnr-helper"
-    namespace = "kellnr"
-  }
+resource "google_storage_bucket" "load_test_bucket" {
+  name          = "kellnr-load-test-${data.terraform_remote_state.infra.outputs.project_id}"
+  project       = data.terraform_remote_state.infra.outputs.project_id
+  location      = data.terraform_remote_state.infra.outputs.region
+  force_destroy = true
+  
+  uniform_bucket_level_access = true
+}
 
-  spec {
-    volume {
-      name = "kellnr-storage-volume"
-      persistent_volume_claim {
-        claim_name = "kellnr-storage-pvc"
-      }
-    }
-
-    container {
-      name    = "helper"
-      image   = "ubuntu:22.04"
-      command = ["sleep", "3600"]
-
-      volume_mount {
-        name       = "kellnr-storage-volume"
-        mount_path = "/data"
-      }
-    }
-  }
+resource "google_storage_bucket_iam_member" "kellnr_gsa_storage_admin" {
+  bucket = google_storage_bucket.load_test_bucket.name
+  role   = "roles/storage.objectAdmin"
+  member = "serviceAccount:${data.terraform_remote_state.infra.outputs.gsa_email}"
 }
 
 resource "kubernetes_job" "kellnr_stress_job" {
+  wait_for_completion = false
   metadata {
     name      = "kellnr-stress-job"
     namespace = "kellnr"
   }
 
   spec {
-    parallelism = var.parallelism
-    completions = var.completions
+    parallelism   = var.parallelism
+    completions   = var.completions
     backoff_limit = 0
 
     template {
@@ -44,20 +33,22 @@ resource "kubernetes_job" "kellnr_stress_job" {
       }
 
       spec {
-        restart_policy = "Never"
-
-        volume {
-          name = "kellnr-storage-volume"
-          persistent_volume_claim {
-            claim_name = "kellnr-storage-pvc"
-          }
-        }
+        restart_policy       = "Never"
+        service_account_name = "kellnr-ksa"
 
         container {
           name    = "load-generator"
-          image   = "ubuntu:22.04"
+          image   = "google/cloud-sdk:slim"
           command = ["/bin/bash", "-c"]
-          args    = ["chmod +x /data/stress-test && /data/stress-test"]
+          args    = [
+            <<-EOT
+            gsutil cp gs://${google_storage_bucket.load_test_bucket.name}/stress-test /tmp/stress-test
+            gsutil cp gs://${google_storage_bucket.load_test_bucket.name}/packages.txt /tmp/packages.txt
+            chmod +x /tmp/stress-test
+            /tmp/stress-test
+            gsutil cp /tmp/stress_test_result.csv gs://${google_storage_bucket.load_test_bucket.name}/results/stress_test_$${POD_NAME}.csv
+            EOT
+          ]
 
           env {
             name  = "GKE_IP"
@@ -89,13 +80,13 @@ resource "kubernetes_job" "kellnr_stress_job" {
           }
 
           env {
-            name  = "CSV_OUT"
-            value = "/data/stress_test_option_b_$(POD_NAME).csv"
+            name  = "PACKAGES_FILE"
+            value = "/tmp/packages.txt"
           }
 
-          volume_mount {
-            name       = "kellnr-storage-volume"
-            mount_path = "/data"
+          env {
+            name  = "CSV_OUT"
+            value = "/tmp/stress_test_result.csv"
           }
 
           resources {
@@ -104,8 +95,8 @@ resource "kubernetes_job" "kellnr_stress_job" {
               memory = "2Gi"
             }
             requests = {
-              cpu    = "500m"
-              memory = "512Mi"
+              cpu    = "2"
+              memory = "2Gi"
             }
           }
         }

--- a/cargo-portal/terraform/load-test/outputs.tf
+++ b/cargo-portal/terraform/load-test/outputs.tf
@@ -1,0 +1,19 @@
+output "stress_instructions" {
+  value = <<EOF
+
+Stress testing infrastructure configured!
+
+To run the load simulations:
+1. Compile the stress-test binary locally for Linux x86_64:
+   cargo build --release --manifest-path ../../stress-test/Cargo.toml
+
+2. Copy the compiled binary into the Filestore NFS share via the helper pod:
+   kubectl cp ../../stress-test/target/release/stress-test kellnr-helper:/data/stress-test -n kellnr
+
+3. Trigger the stress test by running:
+   terraform apply
+
+4. Once the job completes, you can copy the CSV results back to analyze them:
+   kubectl cp kellnr-helper:/data/ . -n kellnr
+EOF
+}

--- a/cargo-portal/terraform/load-test/outputs.tf
+++ b/cargo-portal/terraform/load-test/outputs.tf
@@ -10,6 +10,10 @@ To run the load simulations:
 2. Copy the compiled binary into the Filestore NFS share via the helper pod:
    kubectl cp ../../stress-test/target/release/stress-test kellnr-helper:/data/stress-test -n kellnr
 
+   (Optional) Fetch and copy the top 1000 popular crates to load-test real-world proxy caching:
+   python3 ../../stress-test/get_popular_crates.py 1000
+   kubectl cp packages.txt kellnr-helper:/data/packages.txt -n kellnr
+
 3. Trigger the stress test by running:
    terraform apply
 

--- a/cargo-portal/terraform/load-test/outputs.tf
+++ b/cargo-portal/terraform/load-test/outputs.tf
@@ -1,3 +1,7 @@
+output "load_test_bucket_name" {
+  value = google_storage_bucket.load_test_bucket.name
+}
+
 output "stress_instructions" {
   value = <<EOF
 
@@ -7,17 +11,18 @@ To run the load simulations:
 1. Compile the stress-test binary locally for Linux x86_64:
    cargo build --release --manifest-path ../../stress-test/Cargo.toml
 
-2. Copy the compiled binary into the Filestore NFS share via the helper pod:
-   kubectl cp ../../stress-test/target/release/stress-test kellnr-helper:/data/stress-test -n kellnr
+2. Copy the compiled binary and packages.txt into the GCS load-test bucket:
+   gcloud storage cp ../../stress-test/target/release/stress-test gs://${google_storage_bucket.load_test_bucket.name}/stress-test
 
    (Optional) Fetch and copy the top 1000 popular crates to load-test real-world proxy caching:
    python3 ../../stress-test/get_popular_crates.py 1000
-   kubectl cp packages.txt kellnr-helper:/data/packages.txt -n kellnr
+   gcloud storage cp packages.txt gs://${google_storage_bucket.load_test_bucket.name}/packages.txt
 
 3. Trigger the stress test by running:
    terraform apply
 
-4. Once the job completes, you can copy the CSV results back to analyze them:
-   kubectl cp kellnr-helper:/data/ . -n kellnr
+4. Once the job completes, you can copy the CSV results back from the GCS bucket to analyze them:
+   gcloud storage cp -r gs://${google_storage_bucket.load_test_bucket.name}/results/ .
+
 EOF
 }

--- a/cargo-portal/terraform/load-test/providers.tf
+++ b/cargo-portal/terraform/load-test/providers.tf
@@ -1,0 +1,30 @@
+terraform {
+  required_version = ">= 1.0"
+  required_providers {
+    google = {
+      source  = "hashicorp/google"
+      version = "~> 5.0"
+    }
+    kubernetes = {
+      source  = "hashicorp/kubernetes"
+      version = "~> 2.0"
+    }
+  }
+}
+
+data "terraform_remote_state" "infra" {
+  backend = "local"
+
+  config = {
+    path = "${path.module}/../infra/terraform.tfstate"
+  }
+}
+
+data "google_client_config" "default" {}
+
+# Dynamically configure the Kubernetes provider using remote state outputs of the applied infra module
+provider "kubernetes" {
+  host                   = "https://${data.terraform_remote_state.infra.outputs.gke_cluster_endpoint}"
+  token                  = data.google_client_config.default.access_token
+  cluster_ca_certificate = base64decode(data.terraform_remote_state.infra.outputs.gke_cluster_ca_certificate)
+}

--- a/cargo-portal/terraform/load-test/variables.tf
+++ b/cargo-portal/terraform/load-test/variables.tf
@@ -21,3 +21,9 @@ variable "completions" {
   default     = 16
   description = "Total number of successful pod completions for the Job."
 }
+
+variable "registry_path" {
+  type        = string
+  default     = "/api/v1/cratesio"
+  description = "The target registry path to test (e.g. /api/v1/crates for private registry, or /api/v1/cratesio for crates.io proxy fallback)."
+}

--- a/cargo-portal/terraform/load-test/variables.tf
+++ b/cargo-portal/terraform/load-test/variables.tf
@@ -27,3 +27,11 @@ variable "registry_path" {
   default     = "/api/v1/cratesio"
   description = "The target registry path to test (e.g. /api/v1/crates for private registry, or /api/v1/cratesio for crates.io proxy fallback)."
 }
+
+variable "node_selector" {
+  type        = map(string)
+  default     = {
+    "cloud.google.com/machine-family" = "n2"
+  }
+  description = "Additional node selectors for load generator pods (e.g. {'cloud.google.com/machine-family' = 'n2'})."
+}

--- a/cargo-portal/terraform/load-test/variables.tf
+++ b/cargo-portal/terraform/load-test/variables.tf
@@ -1,0 +1,23 @@
+variable "concurrency" {
+  type        = number
+  default     = 90
+  description = "Number of concurrent workers per stress pod."
+}
+
+variable "duration" {
+  type        = number
+  default     = 45
+  description = "Duration of the stress test run in seconds."
+}
+
+variable "parallelism" {
+  type        = number
+  default     = 16
+  description = "Number of stress generator pods to run concurrently."
+}
+
+variable "completions" {
+  type        = number
+  default     = 16
+  description = "Total number of successful pod completions for the Job."
+}


### PR DESCRIPTION
# Description: Deploy Cargo Portal (Stateless Rust Dependency Proxy on GKE)

## I. Introduction and Purpose

This pull request introduces **Cargo Portal**, a self-hosted Rust dependency caching proxy designed for Google Kubernetes Engine (GKE) Autopilot. Cargo Portal is built on top of **Kellnr**, an open-source Rust registry. It provides a stateless, scalable registry proxy that caches public dependencies from `crates.io` and hosts private crates. This architecture supports high-concurrency developer workloads, such as reinforcement learning training pipelines, while minimizing latency and bandwidth consumption.

We have augmented Kellnr's standard deployment to run in a stateless, production-ready configuration on Google Cloud Platform (GCP) by integrating the following components:

*   **Google Kubernetes Engine (GKE) Autopilot**: Manages the Kellnr container lifecycle and scales registry pods dynamically via a Horizontal Pod Autoscaler (HPA).
*   **Google Cloud SQL PostgreSQL**: Replaces the default SQLite database with a managed, high-performance database instance, enabling multiple stateless Kellnr replicas to share registry metadata.
*   **Google Cloud Storage (GCS)**: Replaces local file storage with a stateless object storage backend, accessed via an S3-compatible API.
*   **GCP Filestore**: Provides an alternative POSIX-compliant Network File System (NFS) storage backend option.
*   **Google Cloud Content Delivery Network (CDN)**: Shields the registry from traffic spikes, reduces latency via edge caching, and prevents backend saturation on cold starts.

---

## II. Core Features

*   **Stateless Scaling**: Kellnr pods are decoupled from stateful storage, allowing the GKE cluster to scale pods horizontally based on CPU demand.
*   **Storage Flexibility**: Supports both object storage (GCS) and file storage (Filestore) backends.
*   **Database Scaling Optimizations**: Configured with optimized PostgreSQL connection settings to support high replica counts.
*   **Secure Internal CDN Routing**: Leverages Google's global frontend edge for caching while keeping traffic strictly internal to the Virtual Private Cloud (VPC).
*   **Automated Cache Warmup**: Includes an in-cluster warmup job to populate regional CDN edge caches prior to launching large concurrent workloads.
*   **Internal Load Generator**: Features a containerized, high-throughput load generator (`stress-test`) deployed as a Kubernetes Job to validate registry performance within the cluster.

---

## III. Internal CDN Routing Architecture

Typically, Google Cloud CDN requires an External HTTPS Load Balancer, which is exposed to the public internet. For secure sandbox environments, Cargo Portal routes traffic to this external load balancer internally using **Private Google Access (PGA)**.

PGA enables VM instances and GKE nodes with private IP addresses to route traffic to Google public IP ranges (including the Load Balancer frontend) internally over Google's private network backbone. The traffic never leaves Google's network, ensuring security isolation while utilizing Cloud CDN caching.

---

## IV. Load-Test Validation Results

We executed stress tests using 16 simulation pods running 90 concurrent threads per pod for 45 seconds. By default, these simulation pods were scheduled on GKE Autopilot's general-purpose nodes (E2 machine family), which have physical network interface cards (NICs) capped at a maximum of 16 Gbps bandwidth.

To simulate a realistic developer workload, the tests did not query a single test crate. Instead, we compiled a list of the top 1000 most popular public crates from `crates.io` and stored them in `packages.txt`. During the load test, each simulation worker randomly selected and requested crates from this list. This created a realistic, high-concurrency dependency resolution pattern that stressed the database with varied row queries rather than hitting a single cached database row.

### Table 1a: GCS Backend with Cloud CDN (Option D) - N2 Unbottlenecked Results
These tests were executed against a developer-tier `db-f1-micro` database (614 MiB RAM) shielded by Cloud CDN, using GCS as the storage backend. Load generator pods were scheduled with Pod Anti-Affinity to guarantee one pod per physical node.

| Test Scenario | Client Node Type | Concurrency (Workers) | Total Requests | Success Rate | Aggregate RPS | Median (P50) Latency | Tail (P99) Latency |
| :--- | :---: | :---: | :---: | :---: | :---: | :---: | :---: |
| Warm Cache Hits (375KB Crates) | N2 (Optimized)* | 1,440 | 8,481,926 | 99.99% | 188,487 RPS | 3 ms | 18 ms |
| Cold Start Fills (375KB Crates) | N2 (Optimized)* | 1,440 | 8,489,823 | 99.99% | 188,662 RPS | 5 ms | 24 ms |
| True Cold Start (55KB Crates) | N2 (Optimized)* | 1,440 | 12,598,393 | 99.99% | 279,964 RPS | 3 ms | 15 ms |

\* *Scheduled with Pod Anti-Affinity to ensure 1 pod per node, maximizing client network capacity.*
\** *Note on True Cold Start (55KB)*: This scenario uses smaller crate payloads (55KB average, compressing to ~5KB) to minimize network bandwidth consumption. This allows the test to push the request rate to the absolute limits of the GFE edge cache and GKE client CPU processing, achieving ~280k RPS. This proves that the system's performance ceiling under larger (375KB) payloads is bound by GKE node NIC bandwidth limits (128 Gbps aggregate) rather than backend database or cache lookup performance.

### Table 1b: GCS Backend with Cloud CDN (Option D) - E2 Baseline Results
These tests were executed against a developer-tier `db-f1-micro` database (614 MiB RAM) shielded by Cloud CDN, using GCS as the storage backend, with default E2 client nodes without anti-affinity constraints.

| Test Scenario | Client Node Type | Concurrency (Workers) | Total Requests | Success Rate | Aggregate RPS | Median (P50) Latency | Tail (P99) Latency |
| :--- | :---: | :---: | :---: | :---: | :---: | :---: | :---: |
| Warm Cache Hits (375KB Crates) | E2 (Default) | 1,440 | 1,067,706 | 99.88% | 23,726 RPS | 16 ms | 675 ms |
| Cold Start Fills (375KB Crates) | E2 (Default) | 1,440 | 970,374 | 99.99% | 21,563 RPS | 15 ms | 902 ms |

---

### Table 2a: Filestore Backend with Cloud CDN (Option A) - N2 Unbottlenecked Results
These tests were executed against a developer-tier `db-f1-micro` database (614 MiB RAM) shielded by Cloud CDN, using Filestore as the storage backend. Load generator pods were scheduled with Pod Anti-Affinity to guarantee one pod per physical node.

| Test Scenario | Client Node Type | Concurrency (Workers) | Total Requests | Success Rate | Aggregate RPS | Median (P50) Latency | Tail (P99) Latency |
| :--- | :---: | :---: | :---: | :---: | :---: | :---: | :---: |
| Warm Cache Hits (375KB Crates) | N2 (Optimized)* | 1,440 | 5,624,884 | 99.94% | 124,997 RPS | 4 ms | 40 ms |
| Cold Start Misses (375KB Crates) | N2 (Optimized)* | 1,440 | 2,055,442 | 99.99% | 45,676 RPS | 12 ms | 247 ms |
| True Cold Start (55KB Crates) | N2 (Optimized)* | 1,440 | 12,634,195 | 99.99% | 280,759 RPS | 3 ms | 14 ms |

\* *Scheduled with Pod Anti-Affinity to ensure 1 pod per node, maximizing client network capacity.*
\** *Note on True Cold Start (55KB)*: This scenario uses smaller crate payloads (55KB average, compressing to ~5KB) to minimize network bandwidth consumption. This allows the test to push the request rate to the absolute limits of the GFE edge cache and GKE client CPU processing, achieving ~280k RPS. This proves that the system's performance ceiling under larger (375KB) payloads is bound by GKE node NIC bandwidth limits (128 Gbps aggregate) rather than backend database or cache lookup performance.

### Table 2b: Filestore Backend with Cloud CDN (Option A) - E2 Baseline Results
These tests were executed against a developer-tier `db-f1-micro` database (614 MiB RAM) shielded by Cloud CDN, using Filestore as the storage backend, with default E2 client nodes without anti-affinity constraints.

| Test Scenario | Client Node Type | Concurrency (Workers) | Total Requests | Success Rate | Aggregate RPS | Median (P50) Latency | Tail (P99) Latency |
| :--- | :---: | :---: | :---: | :---: | :---: | :---: | :---: |
| Warm Cache Hits (375KB Crates) | E2 (Default) | 1,440 | 779,644 | 99.99% | 17,325 RPS | 18 ms | 1,102 ms |
| Cold Start Misses (375KB Crates) | E2 (Default) | 1,440 | 712,358 | 99.99% | 15,830 RPS | 17 ms | 1,384 ms |

---

### Table 3a: GKE Only (No CDN - 11 Replicas / 44 vCPUs) - N2 Results
These tests evaluate raw registry performance without the CDN shield on N2 nodes, using 11 replicas and an upgraded 16 vCPU database (`db-custom-16-61440`). Both client and registry pods were scheduled on N2 nodes with anti-affinity to prevent node sharing.

| Storage Backend | Client Node Type | Max DB Connections | Total Requests | Success Rate | Aggregate RPS | Median (P50) Latency | Tail (P99) Latency | Primary Failure Mode |
| :--- | :---: | :---: | :---: | :---: | :---: | :---: | :---: | :--- |
| GCS | N2 (Optimized) | 100 | 554,657 | 99.28% | 12,325 RPS | 72 ms | 308 ms | Client Timeouts (Status 0) |
| Filestore | N2 (Optimized) | 100 | 824,527 | 99.67% | 18,322 RPS | 21 ms | 402 ms | Client Timeouts (Status 0) |

### Table 3b: GKE Only (No CDN - 11 Replicas / 44 vCPUs) - E2 Baseline Results
These tests evaluate raw registry performance without the CDN shield on default E2 nodes, using 11 replicas on a single physical node and an upgraded 16 vCPU database (`db-custom-16-61440`).

| Storage Backend | Client Node Type | Max DB Connections | Total Requests | Success Rate | Aggregate RPS | Median (P50) Latency | Tail (P99) Latency | Primary Failure Mode |
| :--- | :---: | :---: | :---: | :---: | :---: | :---: | :---: | :--- |
| GCS | E2 (Default) | 100 | 551,790 | 98.66% | 12,262 RPS | 31 ms | 267 ms | Client Timeouts (Status 0) |
| Filestore | E2 (Default) | 100 | 360,482 | 98.45% | 8,010 RPS | 92 ms | 409 ms | Client Timeouts (Status 0) |

---

### Table 4a: GKE Only (No CDN - 22 Replicas / 88 vCPUs) - N2 Results
These tests evaluate raw registry performance without the CDN shield on N2 nodes, using 22 replicas and an upgraded 16 vCPU database (`db-custom-16-61440`). Both client and registry pods were scheduled on N2 nodes with anti-affinity to prevent node sharing.

| Storage Backend | Client Node Type | Max DB Connections | Total Requests | Success Rate | Aggregate RPS | Median (P50) Latency | Tail (P99) Latency | Primary Failure Mode |
| :--- | :---: | :---: | :---: | :---: | :---: | :---: | :---: | :--- |
| GCS | N2 (Optimized) | 100 | 758,594 | 98.77% | 16,857 RPS | 20 ms | 207 ms | Client Timeouts / 500 Errors |
| Filestore | N2 (Optimized) | 100 | 746,406 | 99.07% | 16,586 RPS | 31 ms | 221 ms | Client Timeouts (Status 0) |

### Table 4b: GKE Only (No CDN - 22 Replicas / 88 vCPUs) - E2 Baseline Results
These tests evaluate raw registry performance without the CDN shield on default E2 nodes, using 22 replicas distributed across two physical nodes and an upgraded 16 vCPU database (`db-custom-16-61440`).

| Storage Backend | Client Node Type | Max DB Connections | Total Requests | Success Rate | Aggregate RPS | Median (P50) Latency | Tail (P99) Latency | Primary Failure Mode |
| :--- | :---: | :---: | :---: | :---: | :---: | :---: | :---: | :--- |
| GCS | E2 (Default) | 500 | 148,250 | 98.82% | 3,294 RPS | 200 ms | 3,335 ms | Client Timeouts (Status 0) |
| Filestore | E2 (Default) | 500 | 32,039 | 73.42% | 712 RPS | 1,784 ms | 4,639 ms | DB Pool Timeouts (500) |

---

## V. Systems Engineering Findings and Optimizations

### 1. Database Lock Contention vs. CDN Shielding
During raw GKE-only testing (Table 3 and Table 4), scaling from 11 replicas to 22 replicas reduced throughput (GCS: 12.2k RPS to 3.2k RPS; Filestore: 8.0k RPS to 712 RPS).
*   **Finding**: This degradation is caused by database row-lock contention. Kellnr writes package metadata to the database. Under high concurrency, replicas block each other trying to write to the same rows for popular crates (e.g., `tokio`, `serde`). More replicas increase conflicts, increasing latency.
*   **Analysis**: While scaling up compute and database resources is a viable option to handle this load, utilizing **Cloud CDN** is highly beneficial. The CDN shields the backend by serving 99.9% of reads from the edge and uses **Request Coalescing** to collapse concurrent backend requests for the same uncached crate into a single fetch, avoiding the database lock bottleneck without requiring expensive database hardware.

### 2. GCS Object Storage vs. Filestore NFS
*   **Finding**: GCS outperformed Filestore under peak load (12.2k RPS vs 8.0k RPS at 11 replicas). Filestore (NFS) requires network-level POSIX directory locking to prevent write corruption, causing GKE threads to queue. GCS utilizes stateless Optimistic Concurrency Control (OCC) without locking, allowing faster parallel execution.
*   **Recommendation**: Use **GCS** as the default storage backend. It is more cost-effective and avoids NFS write latency overhead.

### 3. Cascading DB Connection Saturation (Filestore 22n)
*   **Finding**: The 22-replica Filestore test collapsed to 712 RPS and suffered from database connection pool timeouts. Slow Filestore write latency under peak IOPS load caused Kellnr replicas to hold database transactions open longer. This exhausted the connection pools on the pods, saturating the database.
*   **Optimization**: Removed the hardcoded `max_connections = 100` limit from `database.tf` to allow GCP to use default limits (scaling to ~4,500 connections for a 16 vCPU DB), and configured the load-test Job to retry on container failure to survive transient database timeouts.

### 4. Regional CDN Cache Partitioning
*   **Finding**: Cloud CDN caches are regionally partitioned. Warming up the cache from a local workstation only populates the POP closest to that workstation, leaving the GKE cluster region (us-central1) cold and exposing the DB to a thundering herd during the first build.
*   **Optimization**: Implemented an in-cluster warmup script that runs inside the GKE namespace to populate the local regional CDN POP before launching production workloads.

### 5. Client Connection Reuse
*   **Finding**: The load generator was dropping response bodies without reading them, forcing the async runtime (Tokio/hyper) to spawn background drain tasks. Under high concurrency, this created massive CPU overhead and client-side timeouts.
*   **Optimization**: Updated the `stress-test` client to fully read response bodies, enabling clean TCP connection reuse and preventing client-side CPU starvation.

### 6. Client Node NIC Bandwidth Bottleneck & Pod Distribution (E2 vs N2)
*   **Finding**: Initial Warm Cache Hit tests on default E2 nodes were capped at ~17k-23k RPS. Upgrading to N2 nodes but running without pod distribution constraints only improved it to ~86k RPS.
*   **Analysis**: This limit is client-side network capacity. Downloading real crate metadata (megabytes of JSON) moves massive volumes of data, even with GFE's automatic gzip compression (which compresses the 375KB average payload to ~30KB). When 16 load generator pods were packed on a few nodes by GKE Autopilot, they saturated the node-level NIC limits (e.g., 16 Gbps for E2, 8 Gbps for `n2-standard-4`).
*   **Optimization**: Configured the load generator Job with **Pod Anti-Affinity** to force GKE Autopilot to schedule each of the 16 pods on a separate `n2-standard-4` node. This scaled the aggregate client network capacity to **128 Gbps** (16 nodes * 8 Gbps).
*   **Unbottlenecked Results**:
    *   **GCS (Option D) Warm Cache**: Achieved **188,487 RPS** (Success: 99.99%, P50: 3ms, P99: 18ms), moving ~45 Gbps of compressed data.
    *   **Filestore (Option A) Warm Cache**: Achieved **124,997 RPS** (Success: 99.94%, P50: 4ms, P99: 40ms). The slightly lower throughput is due to the cold POP start penalty on the initial run, which was throttled by Filestore NFS write latency on CDN cache misses. Once warm, performance aligns with GCS.
    *   **Small Package Limit (55KB Crates)**: When testing with smaller crates (avg 55KB, compressing to ~5KB), both GCS and Filestore reached the client-side CPU processing limit at **280,000 RPS**, generating **125.7 Gbps** of aggregate network throughput—effectively saturating **98%** of the physical 128 Gbps GKE node NIC limit.
*   **Raw GKE (No CDN) Tests on N2 (True N2 & No Contention)**: We re-ran the GKE-only (no CDN) tests on N2 nodes (with both client and server pods forced onto N2). We applied **Pod Anti-Affinity** to prevent the load generator pods from scheduling on the same nodes as Kellnr registry pods, resolving a major CPU contention bottleneck that had previously dropped performance (e.g., from 14k down to 6k RPS when sharing nodes).
    *   **11 Replicas (44 vCPUs)**: Filestore on N2 reached **18,322 RPS** (a 2.3x increase over E2's 8,010 RPS), benefiting from low NFS protocol latency. GCS on N2 reached **12,325 RPS** (similar to E2's 12,262 RPS), where performance is limited by database row-lock contention rather than compute. The previous run's poor GCS performance (4,143 RPS) and pod panics were resolved by separating client/server workloads.
    *   **22 Replicas (88 vCPUs)**: Filestore reached **16,586 RPS** and GCS reached **16,857 RPS**. This represents a **5x to 23x improvement** over the E2 baseline (3.294 RPS for GCS, 712 RPS for Filestore), which collapsed due to resource starvation.
    *   **Note on Autopilot Node Scaling and Machine Families**: In the N2 tests, we configured GKE Autopilot to provision dedicated **`n2-standard-8`** instances (8 vCPUs, dedicated physical hyperthreads) for Kellnr pods (4 CPU requests each, resulting in 1 pod per node). The E2 baseline used default Autopilot scaling on the **`e2`** machine family (which uses shared-core architecture). The dedicated compute of N2, combined with dynamic node scaling (scaling to ~20+ physical nodes for the 22-replica run), resolved the latency spikes and database pool connection timeouts that caused the E2 baseline to collapse.

